### PR TITLE
공통 컴포넌트 Header 개발

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import "./global.css";
 import "@repo/ui/styles.css";
-import { Footer } from "@repo/ui";
+import { Footer, Header } from "@repo/ui";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <Header workspace="blog" />
         {children}
         <Footer />
       </body>

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>Blog</div>;
+  return <div></div>;
 }

--- a/apps/portfolio/src/app/layout.tsx
+++ b/apps/portfolio/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import "./global.css";
 import "@repo/ui/styles.css";
-import { Footer } from "@repo/ui";
+import { Footer, Header } from "@repo/ui";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <Header workspace="portfolio" />
         {children}
         <Footer />
       </body>

--- a/apps/portfolio/src/app/page.tsx
+++ b/apps/portfolio/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>Portfolio</div>;
+  return <div></div>;
 }

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@repo/utils";
+
+type WorkspaceType = "blog" | "portfolio";
+type HeaderProps = {
+  workspace: WorkspaceType;
+};
+
+export const Header = ({ workspace }: HeaderProps) => {
+  return (
+    <header
+      className={cn("sticky", "top-0", "backdrop-blur-sm", "bg-white/10")}
+    >
+      <div
+        className={cn(
+          "w-[43.75rem]",
+          "h-[3.25rem]",
+          "mx-auto",
+          "flex",
+          "justify-between",
+          "items-center"
+        )}
+      >
+        <a
+          href="/"
+          className={cn("text-primary-linear", "font-extrabold", "text-xl")}
+        >
+          OnlyOn.
+        </a>
+        <div className={cn("flex", "gap-10")}>
+          {workspace === "blog" && (
+            <a
+              href="http://localhost:3001"
+              className={cn("text-primary", "font-semibold")}
+            >
+              Portfolio
+            </a>
+          )}
+          {workspace === "portfolio" && (
+            <a
+              href="http://localhost:3000"
+              className={cn("text-primary", "font-semibold")}
+            >
+              Blog
+            </a>
+          )}
+
+          <a
+            href="https://github.com/yoosion030/onlyon"
+            target="_blank"
+            rel="noreferrer"
+            className={cn("text-primary", "font-semibold")}
+          >
+            Github
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./footer";
+export * from "./header";


### PR DESCRIPTION
### 작업 설명

공통 컴포넌트 Header 개발한 작업입니다.


### 개발 변경사항

- header 컴포넌트 개발 및 각 layout에 추가

### 테스트 방법

1. turbo dev
2. blog(3000), portfolio(3001) 접속
3. 페이지 하단에 footer 컴포넌트가 디자인에 맞게 노출되는지 확인
4. 로고 클릭 시 root로 이동하는 것을 확인
5. blog -> portfolio, portfolio -> blog로 이동할 수 있는 것을 확인


### 스크린샷



#### After
- blog
<img width="784" alt="스크린샷 2025-02-27 오후 9 44 26" src="https://github.com/user-attachments/assets/f0ac8bcf-069c-4686-9e83-315729afb6b8" />


- portfolio
<img width="810" alt="스크린샷 2025-02-27 오후 9 44 34" src="https://github.com/user-attachments/assets/11795abd-dd50-446a-a8b0-c6b300ba1afa" />

### 레퍼런스

refs #6