### PR TITLE
블로그 메인 페이지 레이아웃 적용

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -15,6 +15,7 @@
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.2.0",
     "@repo/ui": "workspace:*",
+    "@vercel/og": "^0.6.5",
     "next": "^15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/blog/src/app/(posts)/2024-03-01-example/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-03-01-example/metadata.ts
@@ -1,7 +1,10 @@
-export const metadata = {
+import { type Post } from "../../../types";
+
+export const metadata: Omit<Post, "slug"> = {
   title: "example post",
   description: "Hello World Page",
   publishDate: new Date("2024-03-01"),
-  posterImage: null,
+  posterImage:
+    "https://dthezntil550i.cloudfront.net/ky/latest/ky2106081752454770020570457/1280_960/9e23a15b-ec93-49e0-9766-b4e7ce508339.png",
   categories: ["개발"],
 };

--- a/apps/blog/src/app/(posts)/2024-03-02-example/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-03-02-example/metadata.ts
@@ -1,0 +1,9 @@
+import { type Post } from "../../../types";
+
+export const metadata: Omit<Post, "slug"> = {
+  title: "개발자 회고 블로그",
+  description: "Hello World Page",
+  publishDate: new Date("2024-03-02"),
+  posterImage: null,
+  categories: ["개발"],
+};

--- a/apps/blog/src/app/(posts)/2024-03-02-example/page.mdx
+++ b/apps/blog/src/app/(posts)/2024-03-02-example/page.mdx
@@ -1,0 +1,3 @@
+# MDX Post example
+
+This is a test post.

--- a/apps/blog/src/app/api/poster-image/route.tsx
+++ b/apps/blog/src/app/api/poster-image/route.tsx
@@ -1,0 +1,45 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const title = searchParams.get("title") || "Untitled";
+  const width = searchParams.get("w") || "350";
+  const height = searchParams.get("h") || "180";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+          borderRadius: "16px",
+          background: "linear-gradient(135deg, #8BB5F5 0%, #A1C3F7 100%)",
+        }}
+      >
+        <p
+          style={{
+            fontSize: "50px",
+            fontWeight: 900,
+            fontFamily: "Arial Black, Arial Bold, Gadget, sans-serif",
+            color: "white",
+            wordBreak: "break-word",
+            maxWidth: "90%",
+            textShadow: "0px 0px 1px white",
+            WebkitTextStroke: "1px white",
+          }}
+        >
+          {title}
+        </p>
+      </div>
+    ),
+    {
+      width: parseInt(width, 10) * 2,
+      height: parseInt(height, 10) * 2,
+    }
+  );
+}

--- a/apps/blog/src/app/getPosts.ts
+++ b/apps/blog/src/app/getPosts.ts
@@ -1,7 +1,8 @@
 import { readdir } from "fs/promises";
 import path from "path";
+import { type Post } from "../types";
 
-export async function getPosts() {
+export async function getPosts(): Promise<Post[]> {
   const postPath = path.resolve(process.cwd(), "src", "app", "(posts)");
 
   const slugs = (await readdir(postPath, { withFileTypes: true })).filter(
@@ -15,5 +16,6 @@ export async function getPosts() {
     })
   );
 
+  posts.sort((a, b) => b.publishDate.getTime() - a.publishDate.getTime());
   return posts;
 }

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import "./global.css";
 import "@repo/ui/styles.css";
-import { Footer, Header } from "@repo/ui";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,11 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
-        <Header workspace="blog" />
-        {children}
-        <Footer />
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -1,7 +1,28 @@
+import { cn } from "@repo/utils";
 import { getPosts } from "./getPosts";
+import Post from "../components/Post";
+import RepresentPost from "../components/RepresentPost";
+import { Header, Footer } from "@repo/ui";
 
 export default async function Home() {
-  const test = await getPosts();
-  console.log({ test });
-  return <div>{test.map((post) => post.slug)}</div>;
+  const posts = await getPosts();
+
+  const representPost = posts[0];
+  const otherPosts = posts.slice(1);
+
+  return (
+    <div className={cn("max-w-[75rem]", "mx-auto", "px-8")}>
+      <Header workspace="blog" />
+
+      <main className={cn("mx-auto", "flex", "flex-col", "gap-[3.125rem]")}>
+        {representPost && <RepresentPost post={representPost} />}
+        <div className={cn("grid", "grid-cols-3", "gap-y-5")}>
+          {otherPosts.map((post, index) => (
+            <Post key={`${post.title}-${index}`} post={post} />
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
 }

--- a/apps/blog/src/components/GeneratedPosterImage.tsx
+++ b/apps/blog/src/components/GeneratedPosterImage.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@repo/utils";
+import Image, { ImageProps } from "next/image";
+
+type GeneratedPosterImageProps = {
+  title: string;
+  width: number;
+  height: number;
+} & Omit<ImageProps, "src">;
+
+const GeneratedPosterImage = ({
+  title,
+  width,
+  height,
+  ...props
+}: GeneratedPosterImageProps) => {
+  const apiUrl = `/api/poster-image?title=${encodeURIComponent(title)}&w=${width}&h=${height}`;
+
+  return (
+    <Image
+      src={apiUrl}
+      className={cn("aspect-video", "rounded-2xl")}
+      width={width}
+      height={height}
+      {...props}
+    />
+  );
+};
+
+export default GeneratedPosterImage;

--- a/apps/blog/src/components/Post.tsx
+++ b/apps/blog/src/components/Post.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@repo/utils";
+import { type Post } from "../types";
+import GeneratedPosterImage from "./GeneratedPosterImage";
+import Link from "next/link";
+
+const Post = ({ post }: { post: Post }) => {
+  const { title, description, publishDate, posterImage, categories, slug } =
+    post;
+
+  return (
+    <Link href={slug} className={cn("max-w-[21.875rem]")}>
+      {posterImage ? (
+        <img
+          src={posterImage}
+          alt={title}
+          width="350"
+          height="180"
+          className={cn("aspect-video", "rounded-2xl")}
+        />
+      ) : (
+        <GeneratedPosterImage
+          title={title}
+          width={350}
+          height={180}
+          alt={title}
+        />
+      )}
+
+      <div className={cn("flex", "flex-col", "gap-1", "py-3")}>
+        <p className={cn("text-primary-400", "font-thin", "text-[0.75rem]")}>
+          {publishDate.toLocaleDateString()} | {categories.join(", ")}
+        </p>
+        <h1 className={cn("text-primary-linear", "font-bold")}>{title}</h1>
+        <p className={cn("text-primary-400", "font-thin", "text-[0.75rem]")}>
+          {description}
+        </p>
+      </div>
+    </Link>
+  );
+};
+
+export default Post;

--- a/apps/blog/src/components/RepresentPost.tsx
+++ b/apps/blog/src/components/RepresentPost.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@repo/utils";
+import { type Post } from "../types";
+import BasePosterImage from "./GeneratedPosterImage";
+import Link from "next/link";
+
+const RepresentPost = ({ post }: { post: Post }) => {
+  const { title, description, publishDate, posterImage, categories, slug } =
+    post;
+
+  return (
+    <Link href={slug} className={cn("max-w-[43.75rem]")}>
+      {posterImage ? (
+        <img
+          src={posterImage}
+          alt={title}
+          width="700"
+          height="360"
+          className={cn("aspect-video", "rounded-2xl")}
+        />
+      ) : (
+        <BasePosterImage title={title} width={700} height={360} alt={title} />
+      )}
+
+      <div className={cn("flex", "flex-col", "gap-1", "py-3")}>
+        <p className={cn("text-primary-400", "font-thin", "text-[0.75rem]")}>
+          {publishDate.toLocaleDateString()} | {categories.join(", ")}
+        </p>
+        <h1
+          className={cn("text-primary-linear", "font-bold", "text-[1.75rem]")}
+        >
+          {title}
+        </h1>
+        <p className={cn("text-primary-400", "font-thin", "text-[0.75rem]")}>
+          {description}
+        </p>
+      </div>
+    </Link>
+  );
+};
+
+export default RepresentPost;

--- a/apps/blog/src/types/Post.ts
+++ b/apps/blog/src/types/Post.ts
@@ -1,0 +1,8 @@
+export type Post = {
+  slug: string;
+  title: string;
+  description: string;
+  publishDate: Date;
+  posterImage: string | null;
+  categories: string[];
+};

--- a/apps/blog/src/types/index.ts
+++ b/apps/blog/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./Post";

--- a/apps/portfolio/src/app/layout.tsx
+++ b/apps/portfolio/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./global.css";
 import "@repo/ui/styles.css";
 import { Footer, Header } from "@repo/ui";
+import { cn } from "@repo/utils";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body className={cn("max-w-[43.75rem]", "mx-auto", "px-8")}>
         <Header workspace="portfolio" />
         {children}
         <Footer />

--- a/packages/ui/src/components/footer.tsx
+++ b/packages/ui/src/components/footer.tsx
@@ -3,9 +3,7 @@ import { GithubIcon, LinkedinIcon, VelogIcon } from "../assets";
 
 export const Footer = () => {
   return (
-    <footer
-      className={cn("w-[43.75rem]", "h-[12.5rem]", "space-y-4", "mx-auto")}
-    >
+    <footer className={cn("w-full", "h-[12.5rem]", "space-y-4", "mx-auto")}>
       <p className={cn("text-[0.75rem]", "font-thin", "text-primary-linear")}>
         ©2025. OnlyOn all rights reserved.
       </p>

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -12,7 +12,7 @@ export const Header = ({ workspace }: HeaderProps) => {
     >
       <div
         className={cn(
-          "w-[43.75rem]",
+          "w-full",
           "h-[3.25rem]",
           "mx-auto",
           "flex",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@vercel/og':
+        specifier: ^0.6.5
+        version: 0.6.5
       next:
         specifier: ^15.1.6
         version: 15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -583,6 +586,15 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
+  '@resvg/resvg-wasm@2.4.0':
+    resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
+    engines: {node: '>= 10'}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -766,6 +778,10 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/og@0.6.5':
+    resolution: {integrity: sha512-GFXtgid3+TcVHTd668a10vGpzAh4Ty/yBZPRxKf1UicI8Vi8EthfvSxcaLW0KvQBBe1+d7TcjecLZHRT8JzQ4g==}
+    engines: {node: '>=16'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -832,6 +848,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -861,6 +881,9 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelize@1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
   caniuse-lite@1.0.30001695:
     resolution: {integrity: sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==}
@@ -917,6 +940,23 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-background-parser@0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+
+  css-box-shadow@1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+
+  css-color-keywords@1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+
+  css-gradient-parser@0.0.16:
+    resolution: {integrity: sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==}
+    engines: {node: '>=16'}
+
+  css-to-react-native@3.2.0:
+    resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -984,6 +1024,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  emoji-regex@10.4.0:
+    resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
+
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
@@ -1024,6 +1067,9 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1143,6 +1189,9 @@ packages:
   fastq@1.18.0:
     resolution: {integrity: sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==}
 
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1252,6 +1301,10 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hex-rgb@4.3.0:
+    resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
+    engines: {node: '>=6'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1492,6 +1545,9 @@ packages:
     resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
     engines: {node: '>= 12.0.0'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1723,9 +1779,15 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-css-color@0.2.1:
+    resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -1751,6 +1813,9 @@ packages:
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -1857,6 +1922,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  satori@0.12.1:
+    resolution: {integrity: sha512-0SbjchvDrDbeXeQgxWVtSWxww7qcFgk3DtSE2/blHOSlLsSHwIqO2fCrtVa/EudJ7Eqno8A33QNx56rUyGbLuw==}
+    engines: {node: '>=16'}
+
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
@@ -1927,6 +1996,9 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  string.prototype.codepointat@0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -1986,6 +2058,9 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2079,6 +2154,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2137,6 +2215,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2437,6 +2518,13 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
 
+  '@resvg/resvg-wasm@2.4.0': {}
+
+  '@shuding/opentype.js@1.4.0-beta.0':
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -2643,6 +2731,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/og@0.6.5':
+    dependencies:
+      '@resvg/resvg-wasm': 2.4.0
+      satori: 0.12.1
+      yoga-wasm-web: 0.3.3
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -2729,6 +2823,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@0.0.8: {}
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -2764,6 +2860,8 @@ snapshots:
       get-intrinsic: 1.2.7
 
   callsites@3.1.0: {}
+
+  camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001695: {}
 
@@ -2815,6 +2913,20 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-background-parser@0.1.0: {}
+
+  css-box-shadow@1.0.0-3: {}
+
+  css-color-keywords@1.0.0: {}
+
+  css-gradient-parser@0.0.16: {}
+
+  css-to-react-native@3.2.0:
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
 
   csstype@3.1.3: {}
 
@@ -2880,6 +2992,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  emoji-regex@10.4.0: {}
 
   enhanced-resolve@5.18.1:
     dependencies:
@@ -2997,6 +3111,8 @@ snapshots:
       acorn: 8.14.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3167,6 +3283,8 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fflate@0.7.4: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3317,6 +3435,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hex-rgb@4.3.0: {}
 
   ignore@5.3.2: {}
 
@@ -3543,6 +3663,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.29.1
       lightningcss-win32-arm64-msvc: 1.29.1
       lightningcss-win32-x64-msvc: 1.29.1
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   locate-path@6.0.0:
     dependencies:
@@ -3975,9 +4100,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@0.2.9: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-css-color@0.2.1:
+    dependencies:
+      color-name: 1.1.4
+      hex-rgb: 4.3.0
 
   parse-entities@4.0.2:
     dependencies:
@@ -4000,6 +4132,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   possible-typed-array-names@1.0.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -4157,6 +4291,20 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  satori@0.12.1:
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-gradient-parser: 0.0.16
+      css-to-react-native: 3.2.0
+      emoji-regex: 10.4.0
+      escape-html: 1.0.3
+      linebreak: 1.1.0
+      parse-css-color: 0.2.1
+      postcss-value-parser: 4.2.0
+      yoga-wasm-web: 0.3.3
+
   scheduler@0.25.0: {}
 
   semver@6.3.1: {}
@@ -4259,6 +4407,8 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  string.prototype.codepointat@0.2.1: {}
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -4330,6 +4480,8 @@ snapshots:
   tailwindcss@4.0.7: {}
 
   tapable@2.2.1: {}
+
+  tiny-inflate@1.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4430,6 +4582,11 @@ snapshots:
 
   undici-types@6.20.0: {}
 
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -4528,5 +4685,7 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
### 작업 설명

블로그 메인 페이지 레이아웃 적용한 작업입니다.

### 개발 변경사항
- @vercel/og 라이브러리를 통해 동적 블로그 썸네일 생성
- footer, header 너비를 유동적으로 설정할 수 있도록 스타일 변경
- 대표 포스팅, 기본 포스팅 컴포넌트 생성


### 테스트 방법

1. turbo dev --filter blog
2. localhost:3000 접속
3. 블로그 루트 페이지에서 대표 포스팅, 일반 포스팅을 확인할 수 있음
4. 클릭 시 블로그 상세 페이지로 이동함
5. 썸네일 이미지가 없는 포스팅의 경우 제목을 기반한 이미지가 생성되는지 확인

### 스크린샷

#### Before
<img width="1757" alt="스크린샷 2025-03-01 오후 5 41 25" src="https://github.com/user-attachments/assets/d7670b4a-d20c-494c-9668-0cb862f8373d" />

#### After

<img width="1234" alt="스크린샷 2025-03-01 오후 5 41 02" src="https://github.com/user-attachments/assets/eea22721-f711-4e8d-a08f-97514938a54d" />


### 레퍼런스

https://www.npmjs.com/package/@vercel/og

https://nextjs-ko.org/docs/app/api-reference/functions/generate-image-metadata