### PR TITLE
포스팅 디자인 시스템에서 링크, 코드, 인용문, 볼드체, 구분선에 대한 스타일을 추가함

### DIFF
--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@repo/utils";
-import { getPosts } from "./getPosts";
+import { getPosts } from "../libs/getPosts";
 import Post from "../components/Post";
 import RepresentPost from "../components/RepresentPost";
 import { Header, Footer } from "@repo/ui";

--- a/apps/blog/src/libs/getPosts.ts
+++ b/apps/blog/src/libs/getPosts.ts
@@ -11,7 +11,7 @@ export async function getPosts(): Promise<Post[]> {
 
   const posts = await Promise.all(
     slugs.map(async ({ name }) => {
-      const { metadata } = await import(`./(posts)/${name}/metadata.ts`);
+      const { metadata } = await import(`../app/(posts)/${name}/metadata.ts`);
       return { slug: name, ...metadata };
     })
   );

--- a/apps/blog/src/mdx-components.tsx
+++ b/apps/blog/src/mdx-components.tsx
@@ -52,6 +52,75 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       <ol className={cn("pl-6", "list-decimal", "my-4")}>{children}</ol>
     ),
     li: ({ children }) => <li className={cn("mb-2")}>{children}</li>,
+    a: ({ children, href }) => (
+      <a
+        href={href}
+        className={cn(
+          "text-primary-400",
+          "hover:text-primary",
+          "underline",
+          "transition-colors",
+          "duration-300",
+          "ease-in-out"
+        )}
+        target={href?.startsWith("http") ? "_blank" : undefined}
+        rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
+      >
+        {children}
+      </a>
+    ),
+    strong: ({ children }) => (
+      <strong className={cn("font-bold", "text-primary-400")}>
+        {children}
+      </strong>
+    ),
+    blockquote: ({ children }) => (
+      <blockquote
+        className={cn(
+          "border-l-2",
+          "border-primary-300",
+          "pl-4",
+          "py-1",
+          "my-4",
+          "bg-primary-50/10",
+          "italic",
+          "text-gray-700",
+          "[&>p:first-child]:mt-0",
+          "[&>p:last-child]:mb-0"
+        )}
+      >
+        {children}
+      </blockquote>
+    ),
+    hr: () => (
+      <hr
+        className={cn(
+          "my-8",
+          "border-0",
+          "h-px",
+          "bg-gray-300",
+          "w-full",
+          "mx-auto"
+        )}
+      />
+    ),
+    code: ({ children }) => (
+      <code
+        className={cn(
+          "bg-gray-100",
+          "text-primary-700",
+          "rounded",
+          "px-1.5",
+          "py-0.5",
+          "font-mono",
+          "text-sm",
+          "border",
+          "border-gray-200"
+        )}
+      >
+        {children}
+      </code>
+    ),
     ...components,
   };
 }


### PR DESCRIPTION



### 작업 설명

### 개발 변경사항

- 링크, 코드, 인용문, 볼드체, 구분선에 대한 스타일 추가
- getPosts 함수를 libs 폴더 하위에 위치하도록 변경


### 테스트 방법

포스트 상세 페이지에 접속하여 링크, 코드, 인용문, 볼드체, 구분선에 대한 스타일 적용되었는지 확인
### 스크린샷

#### Before
<img width="733" alt="스크린샷 2025-04-12 오후 6 59 41" src="https://github.com/user-attachments/assets/07e6e733-3857-4a29-94c1-bdca056d7deb" />
<img width="730" alt="스크린샷 2025-04-12 오후 7 00 11" src="https://github.com/user-attachments/assets/cf56aa4a-ee40-4475-aa4b-740b432e2757" />


<img width="772" alt="스크린샷 2025-04-12 오후 7 00 28" src="https://github.com/user-attachments/assets/2f4e0817-3400-452c-acf9-72b66d9c0426" />


#### After
<img width="479" alt="스크린샷 2025-04-12 오후 6 55 12" src="https://github.com/user-attachments/assets/048b3a70-e600-4286-a9ce-4e6867a71e30" />

> 구분선

<img width="479" alt="스크린샷 2025-04-12 오후 6 58 56" src="https://github.com/user-attachments/assets/ca303770-a06f-4a68-be98-d9388544b921" />

> inline 코드, 볼드체

<img width="495" alt="스크린샷 2025-04-12 오후 6 55 01" src="https://github.com/user-attachments/assets/3fb94e79-83f9-49a8-818b-2e95ecbb0e97" />

> 링크

<img width="519" alt="스크린샷 2025-04-12 오후 6 54 50" src="https://github.com/user-attachments/assets/dd01c683-909e-46df-8822-593efa70a45f" />

> 인용문

### 레퍼런스

refs #16