### PR TITLE
Header 컴포넌트에서 블로그, 포트폴리오 주소를 환경변수로 설정함

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,10 +25,11 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
-    "@types/react": "^19.0.8",
-    "typescript": "^5.7.3",
     "@tailwindcss/cli": "^4.0.6",
-    "@tailwindcss/postcss": "^4.0.3"
+    "@tailwindcss/postcss": "^4.0.3",
+    "@types/node": "^22.15.27",
+    "@types/react": "^19.0.8",
+    "typescript": "^5.7.3"
   },
   "dependencies": {
     "@repo/utils": "workspace:*",

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -29,7 +29,7 @@ export const Header = ({ workspace }: HeaderProps) => {
         <div className={cn("flex", "gap-10")}>
           {workspace === "blog" && (
             <a
-              href="http://localhost:3001"
+              href={process.env.NEXT_PUBLIC_PORTFOLIO_URL}
               className={cn("text-primary", "font-semibold")}
             >
               Portfolio
@@ -37,7 +37,7 @@ export const Header = ({ workspace }: HeaderProps) => {
           )}
           {workspace === "portfolio" && (
             <a
-              href="http://localhost:3000"
+              href={process.env.NEXT_PUBLIC_BLOG_URL}
               className={cn("text-primary", "font-semibold")}
             >
               Blog

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.3
         version: 4.0.7
+      '@types/node':
+        specifier: ^22.15.27
+        version: 22.15.27
       '@types/react':
         specifier: ^19.0.8
         version: 19.0.8
@@ -713,6 +716,9 @@ packages:
 
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
+
+  '@types/node@22.15.27':
+    resolution: {integrity: sha512-5fF+eu5mwihV2BeVtX5vijhdaZOfkQTATrePEaXTcKqI16LhJ7gi2/Vhd9OZM0UojcdmiOCVg5rrax+i1MdoQQ==}
 
   '@types/react-dom@19.0.3':
     resolution: {integrity: sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==}
@@ -2154,6 +2160,9 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -2639,6 +2648,10 @@ snapshots:
   '@types/node@22.13.4':
     dependencies:
       undici-types: 6.20.0
+
+  '@types/node@22.15.27':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/react-dom@19.0.3(@types/react@19.0.8)':
     dependencies:
@@ -4581,6 +4594,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.20.0: {}
+
+  undici-types@6.21.0: {}
 
   unicode-trie@2.0.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "env": ["NEXT_PUBLIC_PORTFOLIO_URL", "NEXT_PUBLIC_BLOG_URL"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION


### 작업 설명

Header 컴포넌트에서 블로그, 포트폴리오 주소를 환경변수로 설정하여 각 환경마다 이동하는 주소를 지정할 수 있도록 환경을 구성한 작업입니다.

### 개발 변경사항

- turo.json에 env 설정 추가
- ui workspace에 @types/node 의존성 추가


### 테스트 방법

1. vercel preview 페이지 진입
   - blog: https://onlyon-blog-o3vmd221s-sions-projects-dbadab44.vercel.app/
   - portfolio: https://onlyon-portfolio-7bs1ii5ep-sions-projects-dbadab44.vercel.app/
2. header 링크 클릭 시 localhost 주소가 아닌 각 workspace의 배포 주소로 이동되는지 확인

#### Before

- 배포 환경에서 header의 링크 클릭 시 localhost 주소로 이동함

#### After

- 배포 환경에서 header의 링크 클릭 시 서비스 환경변수에 저장된 주소로 이동함

### 레퍼런스

refs #24