### PR TITLE
헤더 컴포넌트의 backdrop-filter 스타일이 전체 너비에 적용되도록 수정함

### DIFF
--- a/apps/blog/src/app/(posts)/layout.tsx
+++ b/apps/blog/src/app/(posts)/layout.tsx
@@ -13,10 +13,12 @@ export default function DetailLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className={cn("max-w-[43.75rem]", "mx-auto", "px-8")}>
-      <Header workspace="blog" />
-      <section className={cn("py-2")}>{children}</section>
-      <Footer />
-    </div>
+    <>
+      <Header workspace="blog" className={cn("max-w-[43.75rem]", "px-8")} />
+      <div className={cn("max-w-[43.75rem]", "mx-auto", "px-8")}>
+        <section className={cn("py-2")}>{children}</section>
+      </div>
+      <Footer className={cn("max-w-[43.75rem]", "px-8")} />
+    </>
   );
 }

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -10,18 +10,19 @@ export default async function Home() {
   const otherPosts = posts.slice(1);
 
   return (
-    <div className={cn("max-w-[75rem]", "mx-auto", "px-8")}>
-      <Header workspace="blog" />
-
-      <main className={cn("mx-auto", "flex", "flex-col", "gap-[3.125rem]")}>
-        {representPost && <RepresentPost post={representPost} />}
-        <div className={cn("grid", "grid-cols-3", "gap-y-5")}>
-          {otherPosts.map((post, index) => (
-            <Post key={`${post.title}-${index}`} post={post} />
-          ))}
-        </div>
-      </main>
-      <Footer />
-    </div>
+    <>
+      <Header workspace="blog" className={cn("max-w-[75rem]", "px-8")} />
+      <div className={cn("max-w-[75rem]", "mx-auto", "px-8")}>
+        <main className={cn("mx-auto", "flex", "flex-col", "gap-[3.125rem]")}>
+          {representPost && <RepresentPost post={representPost} />}
+          <div className={cn("grid", "grid-cols-3", "gap-y-5")}>
+            {otherPosts.map((post, index) => (
+              <Post key={`${post.title}-${index}`} post={post} />
+            ))}
+          </div>
+        </main>
+      </div>
+      <Footer className={cn("max-w-[75rem]", "px-8")} />
+    </>
   );
 }

--- a/apps/portfolio/src/app/layout.tsx
+++ b/apps/portfolio/src/app/layout.tsx
@@ -16,10 +16,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={cn("max-w-[43.75rem]", "mx-auto", "px-8")}>
-        <Header workspace="portfolio" />
-        {children}
-        <Footer />
+      <body>
+        <Header
+          workspace="portfolio"
+          className={cn("max-w-[43.75rem]", "px-8")}
+        />
+        <section className={cn("max-w-[43.75rem]", "mx-auto", "px-8")}>
+          {children}
+        </section>
+        <Footer className={cn("max-w-[43.75rem]", "px-8")} />
       </body>
     </html>
   );

--- a/packages/ui/src/components/footer.tsx
+++ b/packages/ui/src/components/footer.tsx
@@ -1,9 +1,17 @@
 import { cn } from "@repo/utils";
 import { GithubIcon, LinkedinIcon, VelogIcon } from "../assets";
+import { HTMLAttributes } from "react";
 
-export const Footer = () => {
+type FooterProps = {
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const Footer = ({ className, ...props }: FooterProps) => {
   return (
-    <footer className={cn("w-full", "h-[12.5rem]", "space-y-4", "mx-auto")}>
+    <footer
+      {...props}
+      className={cn("w-full", "h-[12.5rem]", "space-y-4", "mx-auto", className)}
+    >
       <p className={cn("text-[0.75rem]", "font-thin", "text-primary-linear")}>
         ©2025. OnlyOn all rights reserved.
       </p>

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -1,23 +1,26 @@
 import { cn } from "@repo/utils";
+import { HTMLAttributes } from "react";
 
 type WorkspaceType = "blog" | "portfolio";
 type HeaderProps = {
   workspace: WorkspaceType;
-};
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
 
-export const Header = ({ workspace }: HeaderProps) => {
+export const Header = ({ workspace, className, ...props }: HeaderProps) => {
   return (
     <header
       className={cn("sticky", "top-0", "backdrop-blur-sm", "bg-white/10")}
     >
       <div
+        {...props}
         className={cn(
-          "w-full",
           "h-[3.25rem]",
           "mx-auto",
           "flex",
           "justify-between",
-          "items-center"
+          "items-center",
+          className
         )}
       >
         <a


### PR DESCRIPTION



### 작업 설명
헤더 컴포넌트의 backdrop-filter 스타일이 전체 너비에 적용되도록 수정한 작업입니다.

### 개발 변경사항

- header, footer 컴포넌트에 스타일을 props로 전달받아 backdrop-filter는 전제 너비로 설정하고 컨테이너 너비는 페이지마다 커스텀하게 지정할 수 있도록 변경함

### 스크린샷

#### Before
<img width="1641" alt="스크린샷 2025-06-01 오후 3 16 38" src="https://github.com/user-attachments/assets/00f7f83a-afbf-4d75-b7c7-c5820b750fa0" />

#### After


<img width="1080" alt="스크린샷 2025-06-01 오후 3 18 54" src="https://github.com/user-attachments/assets/3737675b-1d49-4395-a9aa-4e389b3dd449" />
### 레퍼런스

refs #18