### PR TITLE
메인 페이지 추천 포스팅 개발

### DIFF
--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -4,7 +4,11 @@ import createMDX from "@next/mdx";
 const nextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   images: {
-    domains: ["velog.velcdn.com"],
+    remotePatterns: [
+      {
+        hostname: "velog.velcdn.com",
+      },
+    ],
   },
 };
 

--- a/apps/blog/src/app/(posts)/2023-03-24-git/metadata.ts
+++ b/apps/blog/src/app/(posts)/2023-03-24-git/metadata.ts
@@ -5,4 +5,5 @@ export const metadata: Omit<Post, "slug"> = {
   description: "비유 하면서 git 배우기",
   publishDate: new Date("2023-03-24"),
   categories: ["Git"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2023-12-21-portfolio/metadata.ts
+++ b/apps/blog/src/app/(posts)/2023-12-21-portfolio/metadata.ts
@@ -8,4 +8,5 @@ export const metadata: Omit<Post, "slug"> = {
   posterImage:
     "https://velog.velcdn.com/images/yoosion030/post/cc68d194-ed3a-41f5-9c77-83efda460c06/image.png",
   categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2024-01-08-skill_interview/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-01-08-skill_interview/metadata.ts
@@ -6,4 +6,5 @@ export const metadata: Omit<Post, "slug"> = {
     "나만의 면접 준비 방법, 10번의 면접 중 4번의 최종 탈락에도 극복하는 방법",
   publishDate: new Date("2024-01-08"),
   categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2024-01-17-coffe_chat/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-01-17-coffe_chat/metadata.ts
@@ -5,4 +5,5 @@ export const metadata: Omit<Post, "slug"> = {
   description: "잘 질문하는 방법과 커피챗하는 방법",
   publishDate: new Date("2024-01-17"),
   categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2024-03-31-office/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-03-31-office/metadata.ts
@@ -7,4 +7,5 @@ export const metadata: Omit<Post, "slug"> = {
   posterImage:
     "https://velog.velcdn.com/images/yoosion030/post/bf348857-da49-42a2-9f28-ac45802fcf15/image.png",
   categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2024-07-28-ci_cd/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-07-28-ci_cd/metadata.ts
@@ -6,4 +6,5 @@ export const metadata: Omit<Post, "slug"> = {
   posterImage:
     "https://velog.velcdn.com/images/yoosion030/post/e7868136-92c8-4796-bbd0-5cf5183b76ae/image.avif",
   categories: ["CI/CD"],
+  recommended: true,
 };

--- a/apps/blog/src/app/(posts)/2024-08-04-test_code/metadata.ts
+++ b/apps/blog/src/app/(posts)/2024-08-04-test_code/metadata.ts
@@ -6,4 +6,5 @@ export const metadata: Omit<Post, "slug"> = {
   posterImage:
     "https://velog.velcdn.com/images/yoosion030/post/276c2895-da29-46cc-8f88-6c88b967a2f7/image.png",
   categories: ["테스트 코드"],
+  recommended: true,
 };

--- a/apps/blog/src/app/api/posts/recommend/route.tsx
+++ b/apps/blog/src/app/api/posts/recommend/route.tsx
@@ -1,0 +1,41 @@
+import { readdir } from "fs/promises";
+import path from "path";
+import { NextResponse } from "next/server";
+import { type Post } from "@blog/types";
+
+export async function GET(): Promise<
+  NextResponse<Post[] | { error: unknown }>
+> {
+  try {
+    const postPath = path.resolve(process.cwd(), "src", "app", "(posts)");
+
+    const slugs = (await readdir(postPath, { withFileTypes: true })).filter(
+      (dirent) => dirent.isDirectory()
+    );
+
+    const posts: (Post | null)[] = await Promise.all(
+      slugs.map(async ({ name }) => {
+        try {
+          const { metadata } = await import(
+            `../../../../app/(posts)/${name}/metadata.ts`
+          );
+          return { slug: name, ...metadata };
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    const recommendedPosts = posts?.filter(
+      (post): post is Post => post !== null && post.recommended === true
+    );
+
+    const sortedPosts = recommendedPosts
+      ?.sort((a, b) => b.publishDate.getTime() - a.publishDate.getTime())
+      .slice(0, 5);
+
+    return NextResponse.json(sortedPosts);
+  } catch (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { cn } from "@repo/utils";
-import { Post, RepresentPost, CategoryFilter } from "@blog/components";
+import {
+  Post,
+  RepresentPost,
+  CategoryFilter,
+  RecommendPost,
+} from "@blog/components";
 import { Header, Footer } from "@repo/ui";
 import { type Post as PostType } from "@blog/types";
 
@@ -19,7 +24,7 @@ export default async function Home(props: HomeProps) {
     return url.toString();
   };
 
-  const [posts, categories] = await Promise.all([
+  const [posts, categories, recommendPosts] = await Promise.all([
     fetch(buildApiUrl("/api/posts"), {
       cache: "force-cache",
     }).then((res) => res.json()) as Promise<PostType[]>,
@@ -29,6 +34,10 @@ export default async function Home(props: HomeProps) {
     }).then((res) => res.json()) as Promise<
       { category: string; count: number }[]
     >,
+
+    fetch(process.env.NEXT_PUBLIC_API_URL + "/api/posts/recommend", {
+      cache: "force-cache",
+    }).then((res) => res.json()) as Promise<PostType[]>,
   ]);
 
   const representPost = posts[0];
@@ -38,10 +47,44 @@ export default async function Home(props: HomeProps) {
     <>
       <Header workspace="blog" className={cn("max-w-[75rem]", "px-8")} />
       <div className={cn("max-w-[75rem]", "mx-auto", "px-8")}>
-        <main className={cn("mx-auto", "flex", "flex-col", "gap-[3.125rem]")}>
+        <main
+          className={cn(
+            "mx-auto",
+            "flex",
+            "flex-col",
+            "gap-[3.125rem]",
+            "my-[3.125rem]"
+          )}
+        >
           <div className={cn("flex", "flex-col", "gap-6")}>
-            <CategoryFilter categories={categories} />
-            {representPost && <RepresentPost post={representPost} />}
+            <div className={cn("flex", "gap-[4.375rem]")}>
+              <div className={cn("max-w-[43.75rem]", "space-y-6")}>
+                <CategoryFilter categories={categories} />
+                {representPost && <RepresentPost post={representPost} />}
+              </div>
+              {recommendPosts.length > 0 && (
+                <div
+                  className={cn("lg:block", "hidden", "flex-1", "space-y-6")}
+                >
+                  <h2
+                    className={cn(
+                      "text-primary-linear",
+                      "font-bold",
+                      "text-[1.75rem]",
+                      "pl-2",
+                      "w-full"
+                    )}
+                  >
+                    추천 포스팅
+                  </h2>
+                  <div className={cn("flex", "flex-col", "gap-4")}>
+                    {recommendPosts.map((post, index) => (
+                      <RecommendPost key={index} {...post} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
           <div className={cn("flex", "flex-col", "gap-[3.125rem]")}>
             {otherPosts.length > 0 && (

--- a/apps/blog/src/components/Category/CategoryBadge.tsx
+++ b/apps/blog/src/components/Category/CategoryBadge.tsx
@@ -41,7 +41,7 @@ const CategoryBadge = ({ category, isActive, count }: CategoryBadgeProps) => {
         "font-medium",
         "border",
         "transition-colors",
-        "hover:bg-primary/10",
+        "hover:bg-primary-400/5",
         isActive
           ? ["bg-primary", "text-white", "border-primary", "hover:text-primary"]
           : ["text-primary", "border-primary", "bg-transparent"]

--- a/apps/blog/src/components/Post/Post.tsx
+++ b/apps/blog/src/components/Post/Post.tsx
@@ -13,7 +13,17 @@ const Post = ({ post }: PostProps) => {
     post;
 
   return (
-    <Link href={slug}>
+    <Link
+      href={slug}
+      className={cn(
+        "hover:bg-primary-400/5",
+        "rounded-2xl",
+        "p-2",
+        "transition",
+        "duration-300",
+        "ease-in-out"
+      )}
+    >
       {posterImage ? (
         <Image
           src={posterImage}

--- a/apps/blog/src/components/Post/RecommendPost.tsx
+++ b/apps/blog/src/components/Post/RecommendPost.tsx
@@ -1,0 +1,30 @@
+import { type Post } from "@blog/types";
+import { cn } from "@repo/utils";
+import Link from "next/link";
+
+const RecommendPost = ({ title, publishDate, categories, slug }: Post) => {
+  return (
+    <Link
+      href={slug}
+      className={cn(
+        "flex",
+        "flex-col",
+        "gap-2",
+        "hover:bg-primary-400/5",
+        "rounded-2xl",
+        "p-2",
+        "transition",
+        "duration-300",
+        "ease-in-out",
+        "w-full"
+      )}
+    >
+      <h2 className={cn("text-primary-400", "font-bold")}>{title}</h2>
+      <p className={cn("text-primary-400", "font-thin", "text-[0.75rem]")}>
+        {new Date(publishDate).toLocaleDateString()} | {categories.join(", ")}
+      </p>
+    </Link>
+  );
+};
+
+export default RecommendPost;

--- a/apps/blog/src/components/Post/RepresentPost.tsx
+++ b/apps/blog/src/components/Post/RepresentPost.tsx
@@ -9,7 +9,19 @@ const RepresentPost = ({ post }: { post: Post }) => {
     post;
 
   return (
-    <Link href={slug} className={cn("max-w-[43.75rem]")}>
+    <Link
+      href={slug}
+      className={cn(
+        "max-w-[43.75rem]",
+        "hover:bg-primary-400/5",
+        "block",
+        "rounded-2xl",
+        "p-2",
+        "transition",
+        "duration-300",
+        "ease-in-out"
+      )}
+    >
       {posterImage ? (
         <Image
           src={posterImage}

--- a/apps/blog/src/components/index.ts
+++ b/apps/blog/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as Post } from "./Post/Post";
 export { default as RepresentPost } from "./Post/RepresentPost";
 export { default as GeneratedPosterImage } from "./Post/GeneratedPosterImage";
+export { default as RecommendPost } from "./Post/RecommendPost";
 export { default as CategoryBadge } from "./Category/CategoryBadge";
 export { default as CategoryFilter } from "./Category/CategoryFilter";

--- a/apps/blog/src/types/Post.ts
+++ b/apps/blog/src/types/Post.ts
@@ -5,4 +5,5 @@ export type Post = {
   publishDate: Date;
   posterImage?: string;
   categories: string[];
+  recommended?: boolean;
 };


### PR DESCRIPTION
### 작업 설명
메인 페이지에서 추천 포스팅을 노출한 작업입니다.


### 개발 변경사항

- post metadata에 recommend 필드 추가
- recommend 포스트 api 추가
- 포스트 hover 스타일 추가


### 테스트 방법

### 스크린샷

#### Before
<img width="985" alt="스크린샷 2025-06-11 오후 9 43 31" src="https://github.com/user-attachments/assets/3cd6a80e-4bf9-409f-a450-27cca14859fe" />

#### After


<img width="1074" alt="스크린샷 2025-06-11 오후 9 43 15" src="https://github.com/user-attachments/assets/4ec2cd77-6d12-41be-84b2-f4dfc82b2761" />

### 레퍼런스

refs #30