### PR TITLE
포스트 상세 페이지의 댓글 서비스 연동

### DIFF
--- a/apps/blog/src/app/(posts)/layout.tsx
+++ b/apps/blog/src/app/(posts)/layout.tsx
@@ -1,4 +1,4 @@
-import { PostToc } from "@blog/components";
+import { PostComment, PostToc } from "@blog/components";
 import { Footer, Header } from "@repo/ui";
 import { cn } from "@repo/utils";
 
@@ -13,6 +13,7 @@ export default function DetailLayout({
 
       <div className={cn("max-w-[52rem]", "mx-auto", "px-8")}>
         <article className={cn("py-2")}>{children}</article>
+        <PostComment />
       </div>
 
       <PostToc />

--- a/apps/blog/src/components/Post/PostComment/PostComment.tsx
+++ b/apps/blog/src/components/Post/PostComment/PostComment.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { cn } from "@repo/utils";
+import { useRef } from "react";
+import useCommentSetting from "./useCommentSetting";
+
+const PostComment = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useCommentSetting({ containerRef });
+
+  return <div className={cn("mb-8")} ref={containerRef}></div>;
+};
+
+export default PostComment;

--- a/apps/blog/src/components/Post/PostComment/index.ts
+++ b/apps/blog/src/components/Post/PostComment/index.ts
@@ -1,0 +1,3 @@
+import PostComment from "./PostComment";
+
+export default PostComment;

--- a/apps/blog/src/components/Post/PostComment/useCommentSetting.ts
+++ b/apps/blog/src/components/Post/PostComment/useCommentSetting.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+
+type CommentSettingProps = {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+};
+
+const useCommentSetting = ({ containerRef }: CommentSettingProps) => {
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const existingScript = containerRef.current.querySelector("script");
+    if (existingScript) {
+      existingScript.remove();
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://giscus.app/client.js";
+    script.setAttribute("data-repo", "yoosion030/onlyon");
+    script.setAttribute("data-repo-id", "R_kgDON72P5w");
+    script.setAttribute("data-category", "General");
+    script.setAttribute("data-category-id", "DIC_kwDON72P584Ctix8");
+    script.setAttribute("data-mapping", "og:title");
+    script.setAttribute("data-strict", "0");
+    script.setAttribute("data-reactions-enabled", "1");
+    script.setAttribute("data-emit-metadata", "0");
+    script.setAttribute("data-input-position", "bottom");
+    script.setAttribute("data-theme", "preferred_color_scheme");
+    script.setAttribute("data-lang", "ko");
+    script.setAttribute("crossorigin", "anonymous");
+    script.setAttribute("async", "true");
+
+    containerRef.current.appendChild(script);
+
+    return () => {
+      if (containerRef.current) {
+        const currentScript = containerRef.current.querySelector("script");
+        if (currentScript) {
+          currentScript.remove();
+        }
+      }
+    };
+  }, []);
+};
+
+export default useCommentSetting;

--- a/apps/blog/src/components/Post/SkeletonPost.tsx
+++ b/apps/blog/src/components/Post/SkeletonPost.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@repo/utils";
 
-const PostSkeleton = () => {
+const SkeletonPost = () => {
   return (
     <div
       className={cn(
@@ -61,4 +61,4 @@ const PostSkeleton = () => {
   );
 };
 
-export default PostSkeleton;
+export default SkeletonPost;

--- a/apps/blog/src/components/Post/index.ts
+++ b/apps/blog/src/components/Post/index.ts
@@ -1,6 +1,7 @@
 export { default as CodeBlock } from "./CodeBlock";
 export { default as GeneratedPosterImage } from "./GeneratedPosterImage";
 export { default as ImageZoom } from "./ImageZoom";
+export { default as PostComment } from "./PostComment";
 export { default as PostHeader } from "./PostHeader/PostHeader";
 export { default as PostHeadingLink } from "./PostHeadingLink/PostHeadingLink";
 export { default as PostItem } from "./PostItem/PostItem";


### PR DESCRIPTION

### 작업 설명

포스트 상세 페이지의 댓글 서비스(giscus)를 연동한 작업입니다.


### 개발 변경사항

- PostComment 컴포넌트에서 giscus 서비스 스크립트 연동
- giscus 깃헙 레포에 연동
- discussions 기능 추가

### 테스트 방법

1. turbo dev
2. localhost:3000 접근 -> 포스팅 상세 페이지 접근
3. 포스팅 하단에 댓글 작성란이 생성되는지 확인
4. 반응 및 댓글을 생성할 수 있으며 작성 시 [github discussion](https://github.com/yoosion030/onlyon/discussions)에 기록되는지 확인

### 스크린샷


#### After


<img width="683" height="280" alt="스크린샷 2025-07-29 오후 11 55 18" src="https://github.com/user-attachments/assets/64fec935-029d-468c-8eb5-b559aef4164c" />

<img width="710" height="501" alt="스크린샷 2025-07-29 오후 11 55 22" src="https://github.com/user-attachments/assets/4ebefac5-e42d-4a26-9a71-59b0c1961497" />

### 레퍼런스

refs #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 본문 하단에 Giscus 기반 댓글 기능이 추가되었습니다.

* **리팩터**
  * 기존 PostSkeleton 컴포넌트의 이름이 SkeletonPost로 변경되었습니다.

* **기타**
  * PostComment 컴포넌트가 새롭게 도입되고, 관련 내보내기가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->