### PR TITLE
블로그 리스트 페이지네이션 구현

### DIFF
--- a/apps/blog/setup-test.tsx
+++ b/apps/blog/setup-test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 import React from "react";
-import { vi } from "vitest";
 
 vi.mock("next/image", () => ({
   default: ({ src, alt, ...props }: { src: string; alt: string }) => (

--- a/apps/blog/src/app/api/posts/all/route.ts
+++ b/apps/blog/src/app/api/posts/all/route.ts
@@ -1,0 +1,37 @@
+import { readdir } from "fs/promises";
+import path from "path";
+import { NextResponse } from "next/server";
+import { type Post } from "@blog/types";
+
+export async function GET(): Promise<
+  NextResponse<Post[] | { error: unknown }>
+> {
+  try {
+    const postPath = path.resolve(process.cwd(), "src", "app", "(posts)");
+
+    const slugs = (await readdir(postPath, { withFileTypes: true })).filter(
+      (dirent) => dirent.isDirectory()
+    );
+
+    const posts: (Post | null)[] = await Promise.all(
+      slugs.map(async ({ name }) => {
+        try {
+          const postModulePath = path.resolve(postPath, name, "page.mdx");
+          const { metadata } = await import(postModulePath);
+
+          return { slug: name, ...metadata };
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    const sortedPosts = posts
+      ?.filter((post): post is Post => post !== null)
+      .sort((a, b) => b?.publishDate.getTime() - a?.publishDate.getTime());
+
+    return NextResponse.json(sortedPosts);
+  } catch (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/apps/blog/src/app/api/posts/category/route.tsx
+++ b/apps/blog/src/app/api/posts/category/route.tsx
@@ -1,14 +1,15 @@
 import { NextResponse } from "next/server";
-import { getPosts } from "@blog/libs";
+import { getAllPosts } from "@blog/libs";
+import { Category } from "@blog/types";
 
 /**
  * 게시글의 카테고리 목록과 각 카테고리별 게시글 수를 반환합니다.
  */
 export async function GET(): Promise<
-  NextResponse<{ category: string; count: number }[] | { error: unknown }>
+  NextResponse<Category[] | { error: unknown }>
 > {
   try {
-    const posts = await getPosts();
+    const posts = await getAllPosts();
     const categoryCountMap = new Map<string, number>();
 
     posts.forEach((post) => {

--- a/apps/blog/src/app/api/posts/recommend/route.tsx
+++ b/apps/blog/src/app/api/posts/recommend/route.tsx
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import { type Post } from "@blog/types";
-import { getPosts } from "@blog/libs";
+import { getAllPosts } from "@blog/libs";
 
 export async function GET(): Promise<
   NextResponse<Post[] | { error: unknown }>
 > {
   try {
-    const posts = await getPosts();
+    const posts = await getAllPosts();
 
     const recommendedPosts = posts
       ?.filter((post) => {

--- a/apps/blog/src/app/api/posts/relation/route.ts
+++ b/apps/blog/src/app/api/posts/relation/route.ts
@@ -1,7 +1,7 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { NextRequest, NextResponse } from "next/server";
 import { type Post } from "@blog/types";
-import { getPosts } from "@blog/libs";
+import { getAllPosts } from "@blog/libs";
 
 const genAI = new GoogleGenerativeAI(
   process.env.NEXT_PUBLIC_GOOGLE_GEMINI_API_KEY || ""
@@ -65,7 +65,7 @@ export async function POST(
     const { currentPost } = await request.json();
     const currentTitle = currentPost?.title || "";
 
-    const allPosts: Post[] = (await getPosts()).filter(
+    const allPosts = (await getAllPosts()).filter(
       (post) => post.title !== currentTitle
     );
 
@@ -87,7 +87,7 @@ export async function POST(
     return NextResponse.json(sortedRecommendations);
   } catch {
     try {
-      const allPosts: Post[] = await getPosts();
+      const allPosts = await getAllPosts();
       const fallback = allPosts
         .sort(
           (a, b) =>

--- a/apps/blog/src/app/api/posts/route.tsx
+++ b/apps/blog/src/app/api/posts/route.tsx
@@ -1,47 +1,46 @@
-import { readdir } from "fs/promises";
-import path from "path";
 import { NextRequest, NextResponse } from "next/server";
 import { type Post } from "@blog/types";
+import { getAllPosts } from "@blog/libs";
+
+type PaginatedResponse = {
+  posts: Post[];
+  totalPages: number;
+};
 
 export async function GET(
   request: NextRequest
-): Promise<NextResponse<Post[] | { error: unknown }>> {
+): Promise<NextResponse<PaginatedResponse | { error: unknown }>> {
   try {
-    const postPath = path.resolve(process.cwd(), "src", "app", "(posts)");
-
-    const slugs = (await readdir(postPath, { withFileTypes: true })).filter(
-      (dirent) => dirent.isDirectory()
-    );
-
-    const posts: (Post | null)[] = await Promise.all(
-      slugs.map(async ({ name }) => {
-        try {
-          const { metadata } = await import(
-            `../../../app/(posts)/${name}/page.mdx`
-          );
-          return { slug: name, ...metadata };
-        } catch {
-          return null;
-        }
-      })
-    );
+    let posts = await getAllPosts();
 
     const { searchParams } = new URL(request.url);
     const category = decodeURIComponent(searchParams.get("category") || "전체");
-
-    let filteredPosts = posts?.filter((post): post is Post => post !== null);
+    const currentPage = parseInt(searchParams.get("page") || "1") || 1;
+    const limit = parseInt(searchParams.get("limit") || "10") || 10;
 
     if (category && category !== "전체") {
-      filteredPosts = filteredPosts.filter((post) =>
+      posts = posts.filter((post) =>
         post.categories?.some((cat) => cat === category)
       );
     }
 
-    const sortedPosts = filteredPosts?.sort(
-      (a, b) => b.publishDate.getTime() - a.publishDate.getTime()
+    const sortedPosts = posts?.sort(
+      (a, b) =>
+        new Date(b.publishDate).getTime() - new Date(a.publishDate).getTime()
     );
 
-    return NextResponse.json(sortedPosts);
+    const totalPosts = sortedPosts.length;
+    const totalPages = Math.ceil(totalPosts / limit);
+    const startIndex = (currentPage - 1) * limit;
+    const endIndex = startIndex + limit;
+    const paginatedPosts = sortedPosts.slice(startIndex, endIndex);
+
+    const response: PaginatedResponse = {
+      posts: paginatedPosts,
+      totalPages,
+    };
+
+    return NextResponse.json(response);
   } catch (error) {
     return NextResponse.json({ error }, { status: 500 });
   }

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={cn("relative")}>{children}</body>
+      <body className={cn("relative")} suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/apps/blog/src/components/Category/CategoryBadge/CategoryBadge.tsx
+++ b/apps/blog/src/components/Category/CategoryBadge/CategoryBadge.tsx
@@ -1,10 +1,9 @@
-import Link from "next/link";
 import { cn } from "@repo/utils";
+import Link from "next/link";
+import { type Category } from "@blog/types";
 
-export type CategoryBadgeProps = {
-  category: string;
+export type CategoryBadgeProps = Category & {
   isActive: boolean;
-  count?: number;
 };
 
 export default function CategoryBadge({
@@ -19,11 +18,12 @@ export default function CategoryBadge({
     <Link
       href={href}
       className={cn(
-        "px-3 py-1 text-[0.625rem] rounded-[0.25rem] font-medium border transition-colors hover:bg-blue-50",
+        "px-3 py-1 text-[0.625rem] rounded-[0.25rem] font-medium border transition-all hover:bg-blue-50 disabled:opacity-50",
         isActive
           ? ["bg-primary", "text-white", "border-primary", "hover:text-primary"]
           : ["text-primary", "border-primary", "bg-transparent"]
       )}
+      prefetch={true}
     >
       {category}
       {count > 0 && <span className="ml-1">({count})</span>}

--- a/apps/blog/src/components/Category/CategoryFilter/CategoryFilter.spec.tsx
+++ b/apps/blog/src/components/Category/CategoryFilter/CategoryFilter.spec.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import CategoryFilter from "./CategoryFilter";
 import { type CategoryBadgeProps } from "../CategoryBadge";

--- a/apps/blog/src/components/Category/CategoryFilter/CategoryFilter.tsx
+++ b/apps/blog/src/components/Category/CategoryFilter/CategoryFilter.tsx
@@ -4,9 +4,10 @@ import { useSearchParams } from "next/navigation";
 
 import { cn } from "@repo/utils";
 import { CategoryBadge } from "@blog/components";
+import { type Category } from "@blog/types";
 
 type CategoryFilterProps = {
-  categories: { category: string; count: number }[];
+  categories: Category[];
 };
 
 const CategoryFilter = ({ categories }: CategoryFilterProps) => {
@@ -17,14 +18,15 @@ const CategoryFilter = ({ categories }: CategoryFilterProps) => {
 
   return (
     <div className={cn("flex", "flex-wrap", "gap-2")}>
-      {categories.map(({ category, count }) => (
-        <CategoryBadge
-          key={category}
-          category={category}
-          isActive={selectedCategory === category}
-          count={count}
-        />
-      ))}
+      {categories.length > 0 &&
+        categories.map(({ category, count }) => (
+          <CategoryBadge
+            key={category}
+            category={category}
+            isActive={selectedCategory === category}
+            count={count}
+          />
+        ))}
     </div>
   );
 };

--- a/apps/blog/src/components/Post/CodeBlock/CodeBlock.test.tsx
+++ b/apps/blog/src/components/Post/CodeBlock/CodeBlock.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { vi, describe, it, expect, beforeEach } from "vitest";
 import CodeBlock from "./CodeBlock";
 import userEvent from "@testing-library/user-event";
 

--- a/apps/blog/src/components/Post/ImageZoom/ImageZoom.test.tsx
+++ b/apps/blog/src/components/Post/ImageZoom/ImageZoom.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { vi, describe, it, expect, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import ImageZoom from "./ImageZoom";
 

--- a/apps/blog/src/components/Post/PostHeader/PostHeader.spec.tsx
+++ b/apps/blog/src/components/Post/PostHeader/PostHeader.spec.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PostHeader from "./PostHeader";
 import { CategoryBadgeProps } from "@blog/components/Category/CategoryBadge";

--- a/apps/blog/src/components/Post/PostHeadingLink/PostHeadingLink.spec.tsx
+++ b/apps/blog/src/components/Post/PostHeadingLink/PostHeadingLink.spec.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { PostHeadingLink } from "./PostHeadingLink";
 import userEvent from "@testing-library/user-event";

--- a/apps/blog/src/components/Post/PostItem/PostItem.spec.tsx
+++ b/apps/blog/src/components/Post/PostItem/PostItem.spec.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PostItem from "./PostItem";
 

--- a/apps/blog/src/components/Post/PostPagination/PostPagination.spec.tsx
+++ b/apps/blog/src/components/Post/PostPagination/PostPagination.spec.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import PostPagination from "./PostPagination";
+import userEvent from "@testing-library/user-event";
+
+const mockPush = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe("PostPagination", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.delete("category");
+    mockSearchParams.delete("page");
+  });
+
+  it("totalPages가 1 이하일 때는 페이지네이션 버튼이 노출되지 않아야 한다.", () => {
+    const { container } = render(
+      <PostPagination currentPage={1} totalPages={1} />
+    );
+    expect(container.firstChild).toBeNull();
+
+    const { container: container2 } = render(
+      <PostPagination currentPage={1} totalPages={0} />
+    );
+    expect(container2.firstChild).toBeNull();
+  });
+
+  it("현재 페이지가 1일 때 이전 버튼이 비활성화되어야 한다.", () => {
+    render(<PostPagination currentPage={1} totalPages={5} />);
+
+    const previousButton = screen.getByRole("button", {
+      name: "이전 페이지로 이동",
+    });
+    expect(previousButton).toHaveAttribute("disabled");
+  });
+
+  it("현재 페이지가 마지막 페이지일 때 다음 버튼이 비활성화되어야 한다.", () => {
+    render(<PostPagination currentPage={5} totalPages={5} />);
+
+    const nextButton = screen.getByRole("button", {
+      name: "다음 페이지로 이동",
+    });
+    expect(nextButton).toHaveAttribute("disabled");
+  });
+
+  it("Previous 버튼 클릭 시 이전 페이지로 이동해야 한다.", async () => {
+    render(<PostPagination currentPage={3} totalPages={5} />);
+
+    const previousButton = screen.getByRole("button", {
+      name: "이전 페이지로 이동",
+    });
+    await userEvent.click(previousButton);
+
+    expect(mockPush).toHaveBeenCalledWith("?page=2");
+  });
+
+  it("Next 버튼 클릭 시 다음 페이지로 이동해야 한다.", async () => {
+    render(<PostPagination currentPage={3} totalPages={5} />);
+
+    const nextButton = screen.getByRole("button", {
+      name: "다음 페이지로 이동",
+    });
+    await userEvent.click(nextButton);
+
+    expect(mockPush).toHaveBeenCalledWith("?page=4");
+  });
+
+  it("첫 번째 페이지에서 Previous 버튼 클릭 시 페이지 이동하지 않아야 한다.", async () => {
+    render(<PostPagination currentPage={1} totalPages={5} />);
+
+    const previousButton = screen.getByRole("button", {
+      name: "이전 페이지로 이동",
+    });
+    await userEvent.click(previousButton);
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("마지막 페이지에서 Next 버튼 클릭 시 페이지 이동하지 않아야 한다.", async () => {
+    render(<PostPagination currentPage={5} totalPages={5} />);
+
+    const nextButton = screen.getByRole("button", {
+      name: "다음 페이지로 이동",
+    });
+    await userEvent.click(nextButton);
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("현재 페이지는 활성 상태로 표시되어야 한다.", () => {
+    render(<PostPagination currentPage={3} totalPages={5} />);
+
+    const currentPageLink = screen.getByRole("link", {
+      name: "3",
+    });
+    expect(currentPageLink).toHaveAttribute("data-active", "true");
+  });
+
+  it("페이지가 많을 때 ellipsis가 표시되어야 한다.", () => {
+    const { container } = render(
+      <PostPagination currentPage={10} totalPages={20} />
+    );
+
+    const ellipsis = container.querySelectorAll(
+      "span[data-slot='pagination-ellipsis']"
+    );
+    expect(ellipsis.length).toBeGreaterThan(0);
+  });
+
+  describe("URL 생성", () => {
+    it("카테고리가 없다면 페이지만 포함된 URL이 생성되어야 한다.", () => {
+      render(<PostPagination currentPage={1} totalPages={3} />);
+
+      const pageLink = screen.getByRole("link", {
+        name: "2",
+      });
+      expect(pageLink).toHaveAttribute("href", "?page=2");
+    });
+
+    it("선택된 카테고리가 있다면 카테고리가 포함된 페이지 URL이 생성되어야 한다.", () => {
+      mockSearchParams.set("category", "JavaScript");
+
+      render(<PostPagination currentPage={1} totalPages={3} />);
+
+      const pageLink = screen.getByRole("link", {
+        name: "2",
+      });
+      expect(pageLink).toHaveAttribute("href", "?category=JavaScript&page=2");
+    });
+  });
+});

--- a/apps/blog/src/components/Post/PostPagination/PostPagination.tsx
+++ b/apps/blog/src/components/Post/PostPagination/PostPagination.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { cn } from "@repo/utils";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@repo/ui";
+
+import { getPagination } from "./pagination";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type PostPaginationProps = {
+  currentPage: number;
+  totalPages: number;
+};
+
+const PostPagination = ({ currentPage, totalPages }: PostPaginationProps) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const createPageUrl = (page: number) => {
+    const params = new URLSearchParams(searchParams);
+    const category = params.get("category");
+    params.set("page", page.toString());
+
+    if (category) {
+      params.set("category", category);
+    }
+    return `?${params.toString()}`;
+  };
+
+  const handlePageChange = (page: number) => {
+    const url = createPageUrl(page);
+    router.push(url);
+  };
+
+  if (totalPages <= 1) return null;
+
+  const visiblePages = getPagination(currentPage, totalPages);
+
+  return (
+    <Pagination className={cn("w-full", "flex", "justify-center")}>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            onClick={() => {
+              if (currentPage === 1) return;
+
+              handlePageChange(currentPage - 1);
+            }}
+            disabled={currentPage === 1}
+          />
+        </PaginationItem>
+
+        {visiblePages.map((page, index) => (
+          <PaginationItem key={index}>
+            {page === "..." ? (
+              <PaginationEllipsis />
+            ) : (
+              <PaginationLink
+                href={createPageUrl(page)}
+                isActive={currentPage === page}
+                className={cn("text-primary-400")}
+              >
+                {page}
+              </PaginationLink>
+            )}
+          </PaginationItem>
+        ))}
+
+        <PaginationItem>
+          <PaginationNext
+            onClick={() => {
+              if (currentPage === totalPages) return;
+
+              handlePageChange(currentPage + 1);
+            }}
+            disabled={currentPage === totalPages}
+            className={cn("text-primary-400")}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};
+
+export default PostPagination;

--- a/apps/blog/src/components/Post/PostPagination/index.ts
+++ b/apps/blog/src/components/Post/PostPagination/index.ts
@@ -1,0 +1,3 @@
+import PostPagination from "./PostPagination";
+
+export default PostPagination;

--- a/apps/blog/src/components/Post/PostPagination/pagination.ts
+++ b/apps/blog/src/components/Post/PostPagination/pagination.ts
@@ -1,0 +1,59 @@
+export const DOTS = "...";
+
+export type PaginationType = (typeof DOTS | number)[];
+
+const range = (start: number, end: number) => {
+  const length = end - start + 1;
+
+  return Array.from({ length }, (_, index) => index + start);
+};
+
+export function getPagination(
+  currentPage: number,
+  totalPageCount: number,
+  siblingCount = 1
+): PaginationType {
+  if (!currentPage || !totalPageCount) {
+    return [];
+  }
+  const pageNums = siblingCount + 6;
+
+  if (pageNums >= totalPageCount) {
+    return range(1, totalPageCount);
+  }
+
+  const leftSiblingIndex = Math.max(currentPage - siblingCount, 1);
+  const rightSiblingIndex = Math.min(
+    currentPage + siblingCount,
+    totalPageCount
+  );
+
+  const shouldShowLeftDots = leftSiblingIndex > 3;
+  const shouldShowRightDots = rightSiblingIndex < totalPageCount - 2;
+
+  const firstPageIndex = 1;
+  const lastPageIndex = totalPageCount;
+
+  if (!shouldShowLeftDots && shouldShowRightDots) {
+    const leftItemCount = 3 + 2 * siblingCount;
+    const leftRange = range(1, leftItemCount);
+
+    return [...leftRange, DOTS, totalPageCount];
+  }
+
+  if (shouldShowLeftDots && !shouldShowRightDots) {
+    const rightItemCount = 3 + 2 * siblingCount;
+    const rightRange = range(
+      totalPageCount - rightItemCount + 1,
+      totalPageCount
+    );
+    return [firstPageIndex, DOTS, ...rightRange];
+  }
+
+  if (shouldShowLeftDots && shouldShowRightDots) {
+    const middleRange = range(leftSiblingIndex, rightSiblingIndex);
+    return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex];
+  }
+
+  return [];
+}

--- a/apps/blog/src/components/Post/PostToc/PostToc.spec.tsx
+++ b/apps/blog/src/components/Post/PostToc/PostToc.spec.tsx
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PostToc from "./PostToc";
 import userEvent from "@testing-library/user-event";

--- a/apps/blog/src/components/Post/PostToc/usePostToc.spec.ts
+++ b/apps/blog/src/components/Post/PostToc/usePostToc.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, fireEvent } from "@testing-library/react";
 import { usePostToc } from "./usePostToc";
 

--- a/apps/blog/src/components/Post/index.ts
+++ b/apps/blog/src/components/Post/index.ts
@@ -9,3 +9,4 @@ export { default as PostToc } from "./PostToc";
 export { default as SkeletonPost } from "./SkeletonPost";
 export { default as CodeBlock } from "./CodeBlock";
 export { default as ImageZoom } from "./ImageZoom";
+export { default as PostPagination } from "./PostPagination";

--- a/apps/blog/src/libs/getAllPosts.ts
+++ b/apps/blog/src/libs/getAllPosts.ts
@@ -1,0 +1,12 @@
+import { type Post } from "@blog/types";
+
+export const getAllPosts = async (): Promise<Post[]> => {
+  const allPosts: Post[] = await fetch(
+    process.env.NEXT_PUBLIC_API_URL + "/api/posts/all",
+    {
+      cache: "force-cache",
+    }
+  ).then((res) => res.json());
+
+  return allPosts;
+};

--- a/apps/blog/src/libs/getCategory.ts
+++ b/apps/blog/src/libs/getCategory.ts
@@ -1,7 +1,4 @@
-type Category = {
-  category: string;
-  count: number;
-};
+import { type Category } from "@blog/types";
 
 export const getCategory = async (): Promise<Category[]> => {
   const categories: Category[] = await fetch(

--- a/apps/blog/src/libs/getPosts.ts
+++ b/apps/blog/src/libs/getPosts.ts
@@ -2,24 +2,41 @@ import { type Post } from "@blog/types";
 
 type GetPostsProps = {
   category?: string;
+  page?: number;
+  limit?: number;
 };
 
-export const getPosts = async ({ category }: GetPostsProps = {}): Promise<
-  Post[]
-> => {
+type PostResponse = {
+  posts: Post[];
+  totalPages: number;
+};
+
+export const getPosts = async ({
+  category,
+  page = 1,
+  limit = 10,
+}: GetPostsProps = {}): Promise<PostResponse> => {
   const buildApiUrl = (endpoint: string) => {
     const url = new URL(process.env.NEXT_PUBLIC_API_URL + endpoint);
     if (category) {
       url.searchParams.set("category", category);
     }
+    url.searchParams.set("page", page.toString());
+    url.searchParams.set("limit", limit.toString());
     return url.toString();
   };
 
-  const posts: Post[] = await fetch(buildApiUrl("/api/posts"), {
-    next: {
-      tags: ["posts", category || "all"],
-    },
-  }).then((res) => res.json());
+  const { posts, totalPages }: PostResponse = await fetch(
+    buildApiUrl("/api/posts"),
+    {
+      next: {
+        tags: ["posts", category || "all", `page-${page}`],
+      },
+    }
+  ).then((res) => res.json());
 
-  return posts.filter((post): post is Post => post !== null);
+  return {
+    posts,
+    totalPages,
+  };
 };

--- a/apps/blog/src/libs/index.ts
+++ b/apps/blog/src/libs/index.ts
@@ -2,3 +2,4 @@ export * from "./getPosts";
 export * from "./getCategory";
 export * from "./getRecommendPosts";
 export * from "./getRelationPosts";
+export * from "./getAllPosts";

--- a/apps/blog/src/types/Category.ts
+++ b/apps/blog/src/types/Category.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  category: string;
+  count?: number;
+};

--- a/apps/blog/src/types/index.ts
+++ b/apps/blog/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./Post";
+export * from "./Category";

--- a/apps/portfolio/setup-test.tsx
+++ b/apps/portfolio/setup-test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 import React from "react";
-import { vi } from "vitest";
 
 vi.mock("next/image", () => ({
   default: ({ src, alt, ...props }: { src: string; alt: string }) => (

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -15,6 +15,6 @@
     "utils": "src/utils",
     "hooks": "src/hooks",
     "lib": "src/lib",
-    "ui": "src/ui"
+    "ui": "src/components"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,7 +22,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
-    "@tailwindcss/cli": "^4.0.6"
+    "@tailwindcss/cli": "^4.0.11"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@repo/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -39,7 +39,7 @@ export const Header = ({ workspace, className, ...props }: HeaderProps) => {
           {workspace === "blog" && (
             <a
               href={process.env.NEXT_PUBLIC_PORTFOLIO_URL}
-              className={cn("text-primary", "font-semibold")}
+              className={cn("text-primary-linear", "font-semibold")}
             >
               Portfolio
             </a>
@@ -47,7 +47,7 @@ export const Header = ({ workspace, className, ...props }: HeaderProps) => {
           {workspace === "portfolio" && (
             <a
               href={process.env.NEXT_PUBLIC_BLOG_URL}
-              className={cn("text-primary", "font-semibold")}
+              className={cn("text-primary-linear", "font-semibold")}
             >
               Blog
             </a>
@@ -57,7 +57,7 @@ export const Header = ({ workspace, className, ...props }: HeaderProps) => {
             href="https://github.com/yoosion030/onlyon"
             target="_blank"
             rel="noreferrer"
-            className={cn("text-primary", "font-semibold")}
+            className={cn("text-primary-linear", "font-semibold")}
           >
             Github
           </a>

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./footer";
 export * from "./header";
 export * from "./dialog";
+export * from "./pagination";

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react";
+
+import { cn } from "@repo/utils";
+import { Button, buttonVariants } from "./button";
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">;
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+type PaginationPreviousProps = {
+  disabled?: boolean;
+} & React.ComponentProps<typeof Button>;
+
+function PaginationPrevious({
+  className,
+  disabled = false,
+  ...props
+}: PaginationPreviousProps) {
+  return (
+    <Button
+      aria-label="이전 페이지로 이동"
+      size="default"
+      variant="ghost"
+      disabled={disabled}
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+      asChild={false}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">이전</span>
+    </Button>
+  );
+}
+
+type PaginationNextProps = {
+  disabled?: boolean;
+} & React.ComponentProps<typeof Button>;
+
+function PaginationNext({
+  className,
+  disabled = false,
+  ...props
+}: PaginationNextProps) {
+  return (
+    <Button
+      aria-label="다음 페이지로 이동"
+      size="default"
+      variant="ghost"
+      disabled={disabled}
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+      asChild={false}
+    >
+      <span className="hidden sm:block">다음</span>
+      <ChevronRightIcon />
+    </Button>
+  );
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,3 +1,114 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "@repo/tailwind-config/theme.css";
+
+@theme {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  :root {
+    --radius: 0.625rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --chart-1: oklch(0.646 0.222 41.116);
+    --chart-2: oklch(0.6 0.118 184.704);
+    --chart-3: oklch(0.398 0.07 227.392);
+    --chart-4: oklch(0.828 0.189 84.429);
+    --chart-5: oklch(0.769 0.188 70.08);
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
+  }
+
+  .dark {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.269 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.371 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+    --chart-1: oklch(0.488 0.243 264.376);
+    --chart-2: oklch(0.696 0.17 162.48);
+    --chart-3: oklch(0.769 0.188 70.08);
+    --chart-4: oklch(0.627 0.265 303.9);
+    --chart-5: oklch(0.645 0.246 16.439);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.439 0 0);
+  }
+
+  * {
+    border-color: var(--border);
+    outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: workspace:*
         version: link:../typescript-config
       '@tailwindcss/cli':
-        specifier: ^4.0.6
-        version: 4.0.7
+        specifier: ^4.0.11
+        version: 4.1.11
 
   packages/utils:
     dependencies:
@@ -1210,21 +1210,12 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tailwindcss/cli@4.0.7':
-    resolution: {integrity: sha512-CX+cUk3SF0HfYnttiGJUAejFJZWvhsujVchflsrvJ5yzfp033mnbvvMus8llKpX2pWdeXCLZiQEGAMvA4bsBCg==}
+  '@tailwindcss/cli@4.1.11':
+    resolution: {integrity: sha512-7RAFOrVaXCFz5ooEG36Kbh+sMJiI2j4+Ozp71smgjnLfBRu7DTfoq8DsTvzse2/6nDeo2M3vS/FGaxfDgr3rtQ==}
     hasBin: true
-
-  '@tailwindcss/node@4.0.7':
-    resolution: {integrity: sha512-dkFXufkbRB2mu3FPsW5xLAUWJyexpJA+/VtQj18k3SUiJVLdpgzBd1v1gRRcIpEJj7K5KpxBKfOXlZxT3ZZRuA==}
 
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
-
-  '@tailwindcss/oxide-android-arm64@4.0.7':
-    resolution: {integrity: sha512-5iQXXcAeOHBZy8ASfHFm1k0O/9wR2E3tKh6+P+ilZZbQiMgu+qrnfpBWYPc3FPuQdWiWb73069WT5D+CAfx/tg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
 
   '@tailwindcss/oxide-android-arm64@4.1.11':
     resolution: {integrity: sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==}
@@ -1232,22 +1223,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.0.7':
-    resolution: {integrity: sha512-7yGZtEc5IgVYylqK/2B0yVqoofk4UAbkn1ygNpIJZyrOhbymsfr8uUFCueTu2fUxmAYIfMZ8waWo2dLg/NgLgg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@tailwindcss/oxide-darwin-arm64@4.1.11':
     resolution: {integrity: sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-darwin-x64@4.0.7':
-    resolution: {integrity: sha512-tPQDV20fBjb26yWbPqT1ZSoDChomMCiXTKn4jupMSoMCFyU7+OJvIY1ryjqBuY622dEBJ8LnCDDWsnj1lX9nNQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@tailwindcss/oxide-darwin-x64@4.1.11':
@@ -1256,23 +1235,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.0.7':
-    resolution: {integrity: sha512-sZqJpTyTZiknU9LLHuByg5GKTW+u3FqM7q7myequAXxKOpAFiOfXpY710FuMY+gjzSapyRbDXJlsTQtCyiTo5w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@tailwindcss/oxide-freebsd-x64@4.1.11':
     resolution: {integrity: sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
-
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.7':
-    resolution: {integrity: sha512-PBgvULgeSswjd8cbZ91gdIcIDMdc3TUHV5XemEpxlqt9M8KoydJzkuB/Dt910jYdofOIaTWRL6adG9nJICvU4A==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
 
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.11':
     resolution: {integrity: sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==}
@@ -1280,20 +1247,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.0.7':
-    resolution: {integrity: sha512-By/a2yeh+e9b+C67F88ndSwVJl2A3tcUDb29FbedDi+DZ4Mr07Oqw9Y1DrDrtHIDhIZ3bmmiL1dkH2YxrtV+zw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.11':
     resolution: {integrity: sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@tailwindcss/oxide-linux-arm64-musl@4.0.7':
-    resolution: {integrity: sha512-WHYs3cpPEJb/ccyT20NOzopYQkl7JKncNBUbb77YFlwlXMVJLLV3nrXQKhr7DmZxz2ZXqjyUwsj2rdzd9stYdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1304,20 +1259,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.0.7':
-    resolution: {integrity: sha512-7bP1UyuX9kFxbOwkeIJhBZNevKYPXB6xZI37v09fqi6rqRJR8elybwjMUHm54GVP+UTtJ14ueB1K54Dy1tIO6w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@tailwindcss/oxide-linux-x64-musl@4.0.7':
-    resolution: {integrity: sha512-gBQIV8nL/LuhARNGeroqzXymMzzW5wQzqlteVqOVoqwEfpHOP3GMird5pGFbnpY+NP0fOlsZGrxxOPQ4W/84bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1340,22 +1283,10 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.0.7':
-    resolution: {integrity: sha512-aH530NFfx0kpQpvYMfWoeG03zGnRCMVlQG8do/5XeahYydz+6SIBxA1tl/cyITSJyWZHyVt6GVNkXeAD30v0Xg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.11':
     resolution: {integrity: sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.0.7':
-    resolution: {integrity: sha512-8Cva6bbJN7ZJx320k7vxGGdU0ewmpfS5A4PudyzUuofdi8MgeINuiiWiPQ0VZCda/GX88K6qp+6UpDZNVr8HMQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@tailwindcss/oxide-win32-x64-msvc@4.1.11':
@@ -1363,10 +1294,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@tailwindcss/oxide@4.0.7':
-    resolution: {integrity: sha512-yr6w5YMgjy+B+zkJiJtIYGXW+HNYOPfRPtSs+aqLnKwdEzNrGv4ZuJh9hYJ3mcA+HMq/K1rtFV+KsEr65S558g==}
-    engines: {node: '>= 10'}
 
   '@tailwindcss/oxide@4.1.11':
     resolution: {integrity: sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==}
@@ -3497,9 +3424,6 @@ packages:
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
-  tailwindcss@4.0.7:
-    resolution: {integrity: sha512-yH5bPPyapavo7L+547h3c4jcBXcrKwybQRjwdEIVAd9iXRvy/3T1CC6XSQEgZtRySjKfqvo3Cc0ZF1DTheuIdA==}
-
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
 
@@ -4714,22 +4638,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/cli@4.0.7':
+  '@tailwindcss/cli@4.1.11':
     dependencies:
       '@parcel/watcher': 2.5.1
-      '@tailwindcss/node': 4.0.7
-      '@tailwindcss/oxide': 4.0.7
+      '@tailwindcss/node': 4.1.11
+      '@tailwindcss/oxide': 4.1.11
       enhanced-resolve: 5.18.1
-      lightningcss: 1.30.1
       mri: 1.2.0
       picocolors: 1.1.1
-      tailwindcss: 4.0.7
-
-  '@tailwindcss/node@4.0.7':
-    dependencies:
-      enhanced-resolve: 5.18.1
-      jiti: 2.4.2
-      tailwindcss: 4.0.7
+      tailwindcss: 4.1.11
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -4741,55 +4658,28 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.1.11
 
-  '@tailwindcss/oxide-android-arm64@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-android-arm64@4.1.11':
-    optional: true
-
-  '@tailwindcss/oxide-darwin-arm64@4.0.7':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.1.11':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-darwin-x64@4.1.11':
-    optional: true
-
-  '@tailwindcss/oxide-freebsd-x64@4.0.7':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.1.11':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.11':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.0.7':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.11':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-musl@4.0.7':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
@@ -4798,31 +4688,11 @@ snapshots:
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.0.7':
-    optional: true
-
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.11':
-    optional: true
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.0.7':
     optional: true
 
   '@tailwindcss/oxide-win32-x64-msvc@4.1.11':
     optional: true
-
-  '@tailwindcss/oxide@4.0.7':
-    optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.0.7
-      '@tailwindcss/oxide-darwin-arm64': 4.0.7
-      '@tailwindcss/oxide-darwin-x64': 4.0.7
-      '@tailwindcss/oxide-freebsd-x64': 4.0.7
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.0.7
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.0.7
-      '@tailwindcss/oxide-linux-arm64-musl': 4.0.7
-      '@tailwindcss/oxide-linux-x64-gnu': 4.0.7
-      '@tailwindcss/oxide-linux-x64-musl': 4.0.7
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.0.7
-      '@tailwindcss/oxide-win32-x64-msvc': 4.0.7
 
   '@tailwindcss/oxide@4.1.11':
     dependencies:
@@ -7564,8 +7434,6 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.0: {}
-
-  tailwindcss@4.0.7: {}
 
   tailwindcss@4.1.11: {}
 


### PR DESCRIPTION


### 작업 설명

블로그 리스트에 페이지네이션을 구현한 작업입니다.

### 개발 변경사항

- shdacn pagination 컴포넌트 추가
- ui style.css에 css variables 추가
- 전체 포스팅 조회 api 분리 api/posts/all
- 기존 posts api에 페이지 네이션 슬라이싱 추가


### 테스트 방법

1. 블로그 메인 페이지 접근
2. 포스트 하위에 페이지네이션 버튼이 존재하는지 확인
3. 카테고리를 선택한 상태에서 페이지 네이션 버튼 클릭 시 카테고리가 유지된 채로 이동되는지 확인

### 스크린샷

#### Before
<img width="508" alt="스크린샷 2025-07-07 오후 10 57 55" src="https://github.com/user-attachments/assets/c5d8821d-c7d6-4927-809c-dcef5fe95df0" />

#### After

<img width="354" alt="스크린샷 2025-07-07 오후 10 41 22" src="https://github.com/user-attachments/assets/36c64a9b-f6ce-4c05-98bb-ba2982627fbc" /><img width="355" alt="스크린샷 2025-07-07 오후 10 41 26" src="https://github.com/user-attachments/assets/51f4e158-4f57-4cd6-8d20-46a04eee1ea3" />

### 레퍼런스

https://ui.shadcn.com/docs/theming
https://ui.shadcn.com/docs/components/pagination#

refs #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 블로그에 페이지네이션 UI 및 기능이 추가되어 여러 페이지의 게시글을 쉽게 탐색할 수 있습니다.
  * 새로운 버튼 컴포넌트와 페이지네이션 UI 컴포넌트가 추가되었습니다.
  * 게시글 전체 목록 조회, 카테고리별, 추천, 연관 게시글 API가 개선되었습니다.

* **기능 개선**
  * 게시글 및 카테고리 데이터 타입이 통일되어 관리가 쉬워졌습니다.
  * 카테고리, 게시글 목록, 추천 게시글 등 다양한 컴포넌트의 타입과 렌더링 로직이 개선되었습니다.
  * 다크 모드 및 라이트 모드 지원을 위한 색상 및 테마 시스템이 도입되었습니다.

* **버그 수정**
  * 카테고리 및 게시글 관련 컴포넌트의 조건부 렌더링과 스타일링이 개선되었습니다.

* **문서화 및 테스트**
  * 페이지네이션 컴포넌트에 대한 테스트가 추가되었습니다.
  * 여러 테스트 파일에서 불필요한 테스트 라이브러리 import가 정리되었습니다.

* **스타일**
  * 주요 UI 컴포넌트의 색상 및 테마가 일관성 있게 개선되었습니다.
  * 버튼 및 링크 스타일이 업데이트되었습니다.

* **기타**
  * 패키지 의존성(@tailwindcss/cli)이 최신 버전으로 업데이트되었습니다.
  * 내부 모듈 및 타입의 구조가 리팩토링되어 유지보수가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->