### PR TITLE
[apps] theme css가 적용되지 않아 일부 스타일이 생성되지 않던 이슈를 해결함

### DIFF
--- a/apps/blog/src/app/global.css
+++ b/apps/blog/src/app/global.css
@@ -1,2 +1,3 @@
 @import "tailwindcss";
+@import "@repo/ui/theme.css";
 @import "@repo/ui/styles.css";

--- a/apps/blog/src/components/Post/PostToc/PostToc.tsx
+++ b/apps/blog/src/components/Post/PostToc/PostToc.tsx
@@ -39,8 +39,8 @@ const PostToc = () => {
         "top-0",
         "h-full",
         "right-30",
-        "3xl:block",
-        "hidden",
+        "max-3xl:hidden",
+        "block",
         "max-w-[21.875rem]",
       )}
     >

--- a/apps/portfolio/src/app/global.css
+++ b/apps/portfolio/src/app/global.css
@@ -1,2 +1,3 @@
 @import "tailwindcss";
+@import "@repo/ui/theme.css";
 @import "@repo/ui/styles.css";

--- a/apps/portfolio/src/app/layout.tsx
+++ b/apps/portfolio/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <Header workspace="portfolio" className={cn("max-w-[52rem]", "px-8")} />
         <section className={cn("max-w-[52rem]", "mx-auto", "px-8")}>
           {children}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
   ],
   "exports": {
     "./styles.css": "./dist/styles.css",
+    "./theme.css": "./src/styles/theme.css",
     ".": "./src/components/index.ts"
   },
   "scripts": {


### PR DESCRIPTION

### 작업 설명
[apps] theme css가 적용되지 않아 일부 스타일이 생성되지 않던 이슈를 해결한 작업입니다.

primary theme이 ui에서 빌드되면서 apps에서 사용할 떄 스타일이 생성되지 않아 theme css를 따로 분리하였습니다.
### 개발 변경사항

- theme.css를 별도로 export하여 glboal.css에서 import하도록 변경


### 테스트 방법

### 스크린샷

#### Before
<img width="816" alt="스크린샷 2025-07-10 오후 6 47 44" src="https://github.com/user-attachments/assets/49130f96-9301-4252-85ca-ec94bf945df3" />

#### After

<img width="730" alt="스크린샷 2025-07-10 오후 6 49 01" src="https://github.com/user-attachments/assets/c83c3b6e-fede-4927-8774-f00f9f6b414c" />

### 레퍼런스

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 블로그와 포트폴리오 앱에 새로운 테마 CSS가 추가되어 스타일이 확장되었습니다.
  * UI 패키지에서 테마 CSS를 외부에서 사용할 수 있도록 지원합니다.

* **버그 수정**
  * 블로그의 목차(PostToc) 표시 방식이 개선되어, 작은 화면에서는 표시되고 매우 큰 화면에서는 숨겨집니다.

* **기타**
  * 포트폴리오 레이아웃에 hydration 경고 억제 옵션이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->