### PR TITLE
프로젝트 문서화를 위해 README.md 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,101 @@
-# onlyon
-Personal Branding Project
+# Only On
+
+저의 이름(Sion)과 오직 하나뿐인(Only One) 의미를 담아 오직 하나뿐인 개인 브랜딩 서비스인 Only On입니다.
+
+아래 링크에서 각 서비스를 확인할 수 있습니다.
+
+| 서비스 | 링크 | 
+| --- | --- |
+| 기술 블로그 | https://blog.sionly.one |
+| 포트폴리오 | https://portfolio.sionly.one |
+
+<br/>
+
+### 프로젝트 구조
+
+| 애플리케이션 패키지 | 설명 | 문서 |
+| --- | --- | --- |
+| apps/blog | 기술 블로그를 구성하는 애플리케이션입니다. | [문서](apps/blog/README.md) |
+| apps/portfolio | 포트폴리오를 구성하는 애플리케이션입니다. | [문서](apps/portfolio/README.md) |
+
+<br/>
+
+| 내부 패키지 | 설명 | 문서 |
+| --- | --- | --- |
+| @repo/ui | 공용 UI 에셋 및 컴포넌트를 제공하는 패키지입니다. | [문서](packages/ui/README.md) |
+| @repo/utils | 공용 유틸리티 함수를 제공하는 패키지입니다. | [문서](packages/utils/README.md) |
+| @repo/typescript-config | 타입스크립트 설정 파일을 공용으로 정의하기 위한 패키지입니다. | [문서](packages/typescript-config/README.md) |
+| @repo/vitest-config | 테스트 환경을 공용으로 정의하기 위한 패키지입니다. | [문서](packages/vitest-config/README.md) |
+
+<br/>
+
+### 서비스 실행 방법
+
+
+#### 1. 프로젝트 클론
+
+```bash
+git clone https://github.com/sionlyone/onlyon.git
+cd onlyon
+```
+
+#### 2. 프로젝트 의존성 설치
+
+```bash
+pnpm install
+pnpm add -g turbo
+```
+
+#### 3. 환경 세팅
+
+- 각 프로젝트 .env.example을 참고하여 환경변수를 세팅합니다.
+- Node 버전은 20.10.0 이상이어야 합니다.
+
+#### 4. 프로젝트 실행
+
+```bash
+turbo dev
+```
+
+혹은 
+
+```bash
+pnpm dev
+```
+
+#### 5. 빌드 실행
+
+```bash
+turbo build
+```
+
+#### 6. 테스트 실행
+
+```bash
+turbo test
+```
+
+#### 7. 린트 실행
+
+```bash
+turbo lint
+```
+
+#### 8. 린트 자동 수정
+
+```bash
+turbo lint:fix
+```
+
+<br/>
+
+
+### 기술 스택
+
+- TurboRepo
+- Next.js 15 + React 18 + TypeScript
+- Tailwind CSS
+- Vitest
+- MDX
+- Shadcn
+- Docker, AWS ECS, AWS ALB, Cloudflare, S3

--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -1,0 +1,14 @@
+# 페이지 헤더에서 포트폴리오 페이지로 이동할 URL 입니다.
+NEXT_PUBLIC_PORTFOLIO_URL="portfolio.url"
+
+# 블로그 서비스 BASE URL에 접근하기 위한 URL입니다.
+NEXT_PUBLIC_BLOG_URL="blog.url"
+
+# 포스트 데이터를 요청할 API URL입니다.
+NEXT_PUBLIC_API_URL="blog.url"
+
+# 연관 포스팅 조회 시 사용되는 Gemini API Key입니다.
+NEXT_PUBLIC_GOOGLE_GEMINI_API_KEY="AI~~~"
+
+# 현재 개발 환경을 설정합니다 (개발 혹은 운영), 개발환경의 경우 일부 기능(ex. 검색엔진 설정)이 제한됩니다.
+NEXT_PUBLIC_STAGE="dev | prod"

--- a/apps/blog/.gitignore
+++ b/apps/blog/.gitignore
@@ -32,7 +32,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -1,36 +1,310 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Only On 블로그
 
-## Getting Started
+Only On 서비스의 블로그 애플리케이션입니다.
 
-First, run the development server:
+### 프로젝트 실행 명령어
+
+#### 1. 프로젝트 실행
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+turbo dev --filter=blog
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+#### 2. 프로젝트 빌드
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+turbo build --filter=blog
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+#### 3. 프로젝트 테스트
 
-## Learn More
+```bash
+turbo test --filter=blog
+```
 
-To learn more about Next.js, take a look at the following resources:
+테스트 커버리지 확인
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+turbo test:coverage --filter=blog
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+#### 4. 프로젝트 린트
 
-## Deploy on Vercel
+```bash
+turbo lint --filter=blog
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+린트 자동 수정
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+turbo lint:fix --filter=blog
+```
+
+
+#### 5. 의존성 설치
+
+```bash
+pnpm install --filter blog [패키지명]
+```
+
+<br/>
+
+
+### 프로젝트 배포
+
+#### 개발 환경
+PR이 생성되면 자동으로 개발 환경에 배포됩니다. <br/>
+개발 환경에선 robots, sitemap 등 검색 엔진 최적화 설정이 적용되어 있지 않습니다. <br/>
+테스트하기 위한 환경이기 때문에 링크는 공개하지 않습니다. <br/>
+
+개발 환경 배포 workflow: [.github/workflows/app-blog-dev.yml](/.github/workflows/app-blog-dev.yml)
+
+#### 운영 환경
+
+
+main에 푸시가 될 때 자동으로 운영환경에 배포됩니다. <br/>
+
+- 운영 환경 배포 링크: https://blog.sionly.one
+- 운영 환경 배포 workflow: [.github/workflows/app-blog-prod.yml](/.github/workflows/app-blog-prod.yml)
+
+<br/>
+
+### 프로젝트 구조
+
+Next.js App Router 기반으로 아래와 같은 프로젝트 구조로 구성되어 있습니다:
+
+```filetree
+apps/blog/
+├── src
+│   ├── app
+│   │   ├── (posts)
+│   │   │   ├── 2023-03-24-git
+│   │   │   │   └── page.mdx
+│   │   ├── api
+│   │   │   └── posts
+│   │   │       └── route.ts
+│   │   ├── global.css
+│   │   ├── layout.tsx
+│   │   ├── page.tsx
+│   │   └── ...
+│   ├── mdx-components.tsx
+│   ├── libs
+│   │   ├── generateMetadata.ts
+│   │   └── ...
+│   ├── components
+│   │   ├── PostHeader.tsx
+│   │   └── ...
+│   ├── types
+│   │   └── post.ts
+│   ├── hooks
+│   │   └── useGetRelationPosts.ts
+│   ├── libs
+│   │   ├── generateMetadata.ts
+│   │   └── ...
+├── .env
+├── setup-test.tsx
+└── vitest.config.ts
+```
+
+- api: 블로그 포스트 데이터를 관리하는 Next.js API 라우트 디렉토리입니다.
+- mdx-components: MDX 컴포넌트 디렉토리입니다.
+- components: 컴포넌트 디렉토리입니다.
+- types: 타입 디렉토리입니다.
+- libs: 클라이언트 단에서 서버 데이터(metadata, 포스트 데이터)를 관리하는 라이브러리 디렉토리입니다.
+
+
+프로젝트 내에서 절대경로로 접근하도록 `tsconfig.json` 파일에 아래와 같이 설정되어 있습니다:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@blog/types": ["./src/types/index.ts"],
+      "@blog/types/*": ["./src/types/*"],
+      "@blog/libs": ["./src/libs/index.ts"],
+      "@blog/libs/*": ["./src/libs/*"],
+      "@blog/components": ["./src/components/index.ts"],
+      "@blog/components/*": ["./src/components/*"],
+      "@blog/hooks": ["./src/hooks/index.ts"],
+      "@blog/hooks/*": ["./src/hooks/*"]
+    }
+  }
+}
+```
+
+<br/>
+
+### 블로그 작성 방법
+
+1. app 디렉토리 하위의 (posts) 디렉토리에 접근합니다.
+2. 해당 디렉토리 하위에 새로운 폴더를 생성하여 `현재 날짜-포스트제목` 형식으로 폴더명을 설정합니다.
+3. 해당 폴더 내부에 `page.mdx` 파일을 생성합니다.
+4. page.mdx 파일 내부에 포스트 내용을 작성합니다.
+- 이때 포스트의 정보는 post 변수에 정의하고 export 합니다.
+- 포스트 내용대로 메타데이터를 정의하기 위해 동적으로 생성한 메타데이터를 export 합니다.
+- 포스팅 상단에 포스트 정보를 표시하기 위해 `<PostHeader>` 컴포넌트에 post 변수를 props로 전달합니다.
+- 포스팅 하단에 관련 포스트 목록을 표시하기 위해 `<RelationPostList>` 컴포넌트에 post 변수를 props로 전달합니다.
+
+```tsx
+import { generateMetadata } from "@blog/libs";
+
+export const post = {
+  title: "신입 개발자의 포트폴리오 작성법",
+  description:
+    "60개 회사에 지원해서 8개의 회사(오후두시랩, 신한은행, 토스뱅크, 미리디, 데이원컴퍼니, 베이글코드, 클래스팅, 팀스파르타)에 서류 합격한 방법",
+  publishDate: new Date("2023-12-21"),
+  posterImage:
+    "https://onlyon.s3.ap-southeast-2.amazonaws.com/...",
+  categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
+};
+
+export const metadata = generateMetadata({ post });
+
+<PostHeader post={post} />
+
+포스팅 내용
+
+<RelationPostList post={post} />
+```
+
+#### 포스트 정보
+
+기본적으로 포스트의 기본 정보는 다음과 같이 정의합니다:
+
+```tsx
+export const post = {
+  title: "신입 개발자의 포트폴리오 작성법",
+  description:
+    "60개 회사에 지원해서 8개의 회사(오후두시랩, 신한은행, 토스뱅크, 미리디, 데이원컴퍼니, 베이글코드, 클래스팅, 팀스파르타)에 서류 합격한 방법",
+  publishDate: new Date("2023-12-21"),
+  posterImage:
+    "https://onlyon.s3.ap-southeast-2.amazonaws.com/...",
+  categories: ["신입 개발자의 취업 회고"],
+  recommended: true,
+};
+```
+
+- title: 포스트 제목
+- description: 포스트 설명
+- publishDate: 포스트 작성일
+- posterImage: 포스트 이미지
+  - 포스터 이미지가 없는 경우 제목 텍스트를 기반한 기본 이미지를 생성하여 노출됩니다.
+- categories: 포스트 카테고리
+- recommended: 포스트 추천 여부
+  - 추천 포스트여도 목록에는 최신 날짜 기준으로 총 5개만 노출됩니다.
+
+<br/>
+
+### TurboRepo 패키지 의존성
+
+```json
+// apps/blog/package.json
+{
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "@repo/utils": "workspace:*",
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*"
+  }
+}
+```
+
+#### 1. [@repo/ui](/packages/ui/README.md)
+
+공용 UI 컴포넌트를 사용하기 위한 패키지입니다. <br/>
+Header, Footer 등 공용 컴포넌트를 사용하기 위해 아래와 같이 임포트합니다:
+
+```tsx
+import { Footer, Header } from "@repo/ui";
+```
+
+또한, 기본 css 파일을 `global.css`에 정의하여 사용하고 있습니다:
+
+```css
+/* apps/blog/src/app/global.css */
+@import "tailwindcss";
+@import "@repo/ui/theme.css";
+@import "@repo/ui/styles.css";
+```
+
+#### 2. [@repo/utils](/packages/utils/README.md)
+
+공용 유틸리티 함수를 사용하기 위한 패키지입니다.  <br/>
+현재 프로젝트에선 cn 함수만 사용되고 있습니다:
+
+```tsx
+import { cn } from "@repo/utils";
+```
+
+#### 3. [@repo/typescript-config](/packages/typescript-config/README.md)
+
+타입스크립트 설정 파일을 사용하기 위한 패키지입니다.  <br/>
+공용으로 정의된 설정을 extends(확장) 하여 사용하고 있습니다:
+
+```json
+// apps/blog/tsconfig.json
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  }
+}
+```
+
+#### 4. [@repo/vitest-config](/packages/vitest-config/README.md)
+
+테스트 환경을 공용으로 정의하기 위한 패키지입니다.  <br/>
+Vitest의 `mergeConfig`를 통해 설정을 확장하여 사용하고 있습니다:
+
+```tsx
+import { uiConfig } from "@repo/vitest-config/ui";
+
+export default mergeConfig(uiConfig, {
+  resolve: {
+    alias: {
+      "@blog/components": resolve(__dirname, "./src/components"),
+      "@blog/types": resolve(__dirname, "./src/types"),
+      "@blog/utils": resolve(__dirname, "./src/utils"),
+      "@blog/hooks": resolve(__dirname, "./src/hooks"),
+      "@blog/libs": resolve(__dirname, "./src/libs"),
+      "@repo/ui": resolve(
+        __dirname,
+        "../../packages/ui/src/components/index.ts",
+      ),
+      "@repo/utils": resolve(__dirname, "../../packages/utils/index.ts"),
+    },
+  },
+
+  test: {
+    setupFiles: ["./setup-test.tsx"],
+  },
+})
+```
+
+`setup-test.tsx` 파일은 공용으로 사용하지 않고, 프로젝트 루트에 정의하여 사용하고 있습니다:
+
+```tsx
+// apps/blog/setup-test.tsx
+import "@testing-library/jest-dom";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    <img data-testid="next-image" src={src} alt={alt} {...props} />
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+```

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -22,12 +22,12 @@
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.2.0",
     "@repo/ui": "workspace:*",
+    "@repo/utils": "workspace:*",
     "@vercel/og": "^0.6.5",
     "prism-react-renderer": "^2.4.1"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
-    "@repo/utils": "workspace:*",
     "@repo/vitest-config": "workspace:*",
     "@types/mdx": "^2.0.13"
   }

--- a/apps/blog/src/components/Post/ImageZoom/ImageZoom.spec.tsx
+++ b/apps/blog/src/components/Post/ImageZoom/ImageZoom.spec.tsx
@@ -17,8 +17,6 @@ describe("ImageZoom", () => {
   it("이미지가 정상적으로 노출되어야 한다.", () => {
     render(<ImageZoom {...defaultProps} />);
 
-    screen.debug();
-
     const image = screen.getByRole("img");
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute("src", "/test-image.jpg");

--- a/apps/portfolio/.env.example
+++ b/apps/portfolio/.env.example
@@ -1,0 +1,5 @@
+# 포트폴리오 서비스 BASE URL에 접근하기 위한 URL입니다.
+NEXT_PUBLIC_PORTFOLIO_URL="portfolio.url"
+
+# 페이지 헤더에서 블로그 페이지로 이동할 URL 입니다.
+NEXT_PUBLIC_BLOG_URL="blog.url"

--- a/apps/portfolio/.gitignore
+++ b/apps/portfolio/.gitignore
@@ -27,7 +27,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/apps/portfolio/README.md
+++ b/apps/portfolio/README.md
@@ -1,36 +1,187 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/create-next-app).
+# Only On 포트폴리오
 
-## Getting Started
+Only On 서비스의 포트폴리오 애플리케이션입니다.
 
-First, run the development server:
+
+### 프로젝트 실행 명령어
+
+#### 1. 프로젝트 실행
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+turbo dev --filter=portfolio
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+#### 2. 프로젝트 빌드
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+turbo build --filter=portfolio
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load Inter, a custom Google Font.
+#### 3. 프로젝트 테스트
 
-## Learn More
+```bash
+turbo test --filter=portfolio
+```
 
-To learn more about Next.js, take a look at the following resources:
+테스트 커버리지 확인
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+turbo test:coverage --filter=portfolio
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+#### 4. 프로젝트 린트
 
-## Deploy on Vercel
+```bash
+turbo lint --filter=portfolio
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+린트 자동 수정
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+turbo lint:fix --filter=portfolio
+```
+
+
+#### 5. 의존성 설치
+
+```bash
+pnpm install --filter portfolio [패키지명]
+```
+
+<br/>
+
+
+### 프로젝트 배포
+
+#### 개발 환경
+포트폴리오 애플리케이션은 개발 배포 환경이 따로 구축되어 있지 않습니다. <br/>
+그래서 PR이 생성되면 lint, unit-testing만 진행하게 됩니다. <br/>
+
+개발 환경 배포 workflow: [.github/workflows/app-portfolio-dev.yml](/.github/workflows/app-portfolio-dev.yml)
+
+#### 운영 환경
+
+
+main에 푸시가 될 때 자동으로 운영환경에 배포됩니다. <br/>
+
+- 운영 환경 배포 링크: https://portfolio.sionly.one
+- 운영 환경 배포 workflow: [.github/workflows/app-portfolio-prod.yml](/.github/workflows/app-portfolio-prod.yml)
+
+<br/>
+
+
+### TurboRepo 패키지 의존성
+
+```json
+// apps/portfolio/package.json
+{
+  "dependencies": {
+    "@repo/ui": "workspace:*",
+    "@repo/utils": "workspace:*",
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@repo/vitest-config": "workspace:*"
+  }
+}
+```
+
+#### 1. [@repo/ui](/packages/ui/README.md)
+
+공용 UI 컴포넌트를 사용하기 위한 패키지입니다. <br/>
+Header, Footer 등 공용 컴포넌트를 사용하기 위해 아래와 같이 임포트합니다:
+
+```tsx
+import { Footer, Header } from "@repo/ui";
+```
+
+또한, 기본 css 파일을 `global.css`에 정의하여 사용하고 있습니다:
+
+```css
+/* apps/portfolio/src/app/global.css */
+@import "tailwindcss";
+@import "@repo/ui/theme.css";
+@import "@repo/ui/styles.css";
+```
+
+#### 2. [@repo/utils](/packages/utils/README.md)
+
+공용 유틸리티 함수를 사용하기 위한 패키지입니다.  <br/>
+현재 프로젝트에선 cn 함수만 사용되고 있습니다:
+
+```tsx
+import { cn } from "@repo/utils";
+```
+
+#### 3. [@repo/typescript-config](/packages/typescript-config/README.md)
+
+타입스크립트 설정 파일을 사용하기 위한 패키지입니다.  <br/>
+공용으로 정의된 설정을 extends(확장) 하여 사용하고 있습니다:
+
+```json
+// apps/portfolio/tsconfig.json
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  }
+}
+```
+
+#### 4. [@repo/vitest-config](/packages/vitest-config/README.md)
+
+테스트 환경을 공용으로 정의하기 위한 패키지입니다.  <br/>
+Vitest의 `mergeConfig`를 통해 설정을 확장하여 사용하고 있습니다:
+
+```tsx
+import { uiConfig } from "@repo/vitest-config/ui";
+
+export default mergeConfig(uiConfig, {
+  resolve: {
+    alias: {
+      "@portfolio/components": resolve(__dirname, "./src/components"),
+      "@portfolio/types": resolve(__dirname, "./src/types"),
+      "@portfolio/utils": resolve(__dirname, "./src/utils"),
+      "@portfolio/hooks": resolve(__dirname, "./src/hooks"),
+      "@portfolio/libs": resolve(__dirname, "./src/libs"),
+      "@repo/ui": resolve(
+        __dirname,
+        "../../packages/ui/src/components/index.ts",
+      ),
+      "@repo/utils": resolve(__dirname, "../../packages/utils/index.ts"),
+    },
+  },
+
+  test: {
+    setupFiles: ["./setup-test.tsx"],
+  },
+})
+```
+
+`setup-test.tsx` 파일은 공용으로 사용하지 않고, 프로젝트 루트에 정의하여 사용하고 있습니다:
+
+```tsx
+// apps/portfolio/setup-test.tsx
+import "@testing-library/jest-dom";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    <img data-testid="next-image" src={src} alt={alt} {...props} />
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+```
+
+
+

--- a/apps/portfolio/package.json
+++ b/apps/portfolio/package.json
@@ -17,11 +17,11 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@repo/ui": "workspace:*"
+    "@repo/ui": "workspace:*",
+    "@repo/utils": "workspace:*"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
-    "@repo/utils": "workspace:*",
     "@repo/vitest-config": "workspace:*"
   }
 }

--- a/apps/portfolio/tsconfig.json
+++ b/apps/portfolio/tsconfig.json
@@ -7,10 +7,6 @@
       }
     ],
     "paths": {
-      "@portfolio/types": ["./src/types/index.ts"],
-      "@portfolio/types/*": ["./src/types/*"],
-      "@portfolio/libs": ["./src/libs/index.ts"],
-      "@portfolio/libs/*": ["./src/libs/*"],
       "@portfolio/components": ["./src/components/index.ts"],
       "@portfolio/components/*": ["./src/components/*"]
     },

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,70 @@
+# @repo/typescript-config
+
+타입스크립트 설정 파일을 공용으로 정의하기 위한 패키지입니다. <br/>
+
+
+### 패키지 구조
+```filetree
+packages/typescript-config/
+├── base.json
+├── nextjs.json
+├── package.json
+└── react-library.json
+```
+
+<br/>
+
+### 1. base.json
+기본 `tsconfig.json` 파일입니다.
+
+다른 `tsconfig.json` 파일들은 기본적으로 해당 파일을 확장하여 규칙을 정의해야합니다:
+```json
+// packages/typescript-config/nextjs.json
+{
+  "extends": "./base.json",
+}
+```
+
+
+### 2. nextjs.json
+Next.js 프로젝트를 위한 `tsconfig.json` 파일입니다.
+
+Next.js 프로젝트에서 아래와 같이 해당 파일을 확장하여 사용합니다:
+```json
+// apps/blog/tsconfig.json
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+  },
+}
+```
+
+Next.js 프로젝트에서 vitest 테스트를 위해 `vitest/globals`를 참조하고 있습니다.
+```json
+// packages/typescript-config/nextjs.json
+{
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom", "vitest/globals"]
+  }
+}
+```
+
+
+
+### 3. react-library.json
+프로젝트가 아닌 라이브러리 패키지를 위한 `tsconfig.json` 파일입니다.
+
+대표적으로 ui 패키지에서 아래와 같이 해당 파일을 확장하여 사용합니다:
+```json
+// packages/ui/tsconfig.json
+{
+  "extends": "@repo/typescript-config/react-library.json",
+}
+```
+
+

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,137 @@
+# @repo/ui
+
+공용 UI 컴포넌트를 사용하기 위한 패키지입니다. <br/>
+
+
+### 패키지 구조
+
+```filetree
+packages/ui/
+├── package.json
+└── src
+    ├── assets
+    │   ├── favicon.ico
+    │   ├── og-image.png
+    │   └── ...
+    ├── components
+    │   ├── header.tsx
+    │   ├── footer.tsx
+    │   └── ...
+    ├── styles
+    │   ├── styles.css
+    │   └── theme.css
+    └── ...
+├── components.json
+├── package.json
+└── ...
+```
+
+- assets: 공용 아이콘, 이미지 등 정적 파일을 관리하는 디렉토리입니다.
+- components: 공용 컴포넌트를 관리하는 디렉토리입니다.
+- styles: 공용 스타일을 관리하는 디렉토리입니다.
+- components.json: shadcn/ui 패키지를 사용하기 위한 설정 파일입니다.
+
+<br/>
+
+### 프로젝트 실행 방법
+
+#### 1. 프로젝트 실행
+```bash
+turbo dev --filter=@repo/ui
+```
+
+#### 2. 빌드
+```bash
+turbo build --filter=@repo/ui
+```
+
+#### 3. 린트
+```bash
+turbo lint --filter=@repo/ui
+```
+
+#### 4. Shadcn 컴포넌트 추가
+```bash
+cd packages/ui
+pnpm dlx shadcn add avatar
+```
+
+- 추가된 컴포넌트는 src/components 디렉토리에 추가됩니다.
+- 자세한 설정은 [components.json](./components.json) 파일에서 확인할 수 있습니다.
+
+<br/>
+
+
+### TurboRepo 패키지 의존성
+
+```json
+// packages/ui/package.json
+{
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+  },
+  "dependencies": {
+    "@repo/utils": "workspace:*"
+  }
+}
+```
+
+
+#### 1. [@repo/utils](/packages/utils/README.md)
+
+공용 유틸리티 함수를 사용하기 위한 패키지입니다.  <br/>
+현재 프로젝트에선 cn 함수만 사용되고 있습니다:
+
+```tsx
+import { cn } from "@repo/utils";
+```
+
+#### 2. [@repo/typescript-config](/packages/typescript-config/README.md)
+
+타입스크립트 설정 파일을 사용하기 위한 패키지입니다.  <br/>
+공용으로 정의된 설정을 extends(확장) 하여 사용하고 있습니다:
+
+```json
+// packages/ui/tsconfig.json
+{
+  "extends": "@repo/typescript-config/react-library.json",
+}
+```
+
+#### 3. [apps/blog](/apps/blog/README.md), [apps/portfolio](/apps/portfolio/README.md)
+
+직접적으로 의존하고 있진 않지만, 각 애플리케이션에서 `@repo/ui` 패키지에서 내보낸 모듈을 사용하고 있습니다:
+```json
+// packages/ui/package.json
+{
+  "exports": {
+    "./styles.css": "./dist/styles.css",
+    "./theme.css": "./src/styles/theme.css",
+    ".": "./src/components/index.ts",
+    "./assets/*": "./src/assets/*"
+  },
+}
+```
+
+
+기본적으로 components 모듈을 내보냅니다.
+애플리케이션에선 아래와 같이 사용할 수 있습니다:
+```tsx
+import { Button } from "@repo/ui";
+```
+
+assets 모듈은 아래와 같이 사용할 수 있습니다:
+```tsx
+import { favicon } from "@repo/ui/assets/favicon.ico";
+```
+
+
+styles 모듈은 아래와 같이 사용할 수 있습니다:
+```css
+@import "tailwindcss";
+@import "@repo/ui/theme.css";
+@import "@repo/ui/styles.css";
+```
+
+
+

--- a/packages/ui/src/components/header.tsx
+++ b/packages/ui/src/components/header.tsx
@@ -33,7 +33,7 @@ export const Header = ({ workspace, className, ...props }: HeaderProps) => {
           href="/"
           className={cn("text-primary-linear", "font-extrabold", "text-xl")}
         >
-          OnlyOn.
+          Only On.
         </a>
         <div className={cn("flex", "gap-10")}>
           {workspace === "blog" && (

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,76 @@
+# @repo/utils
+
+공용 유틸리티 함수를 사용하기 위한 패키지입니다. <br/>
+
+
+### 패키지 구조
+
+```filetree
+packages/utils/
+├── package.json
+├── cn.ts
+├── index.ts
+└── ...
+```
+
+<br/>
+
+### 1. cn 함수
+
+`tailwind-merge`를 사용하여 클래스를 병합하는 유틸리티 함수입니다.
+
+```tsx
+import { cn } from "@repo/utils";
+
+cn("bg-red-500", "text-white");
+```
+
+<br/>
+
+### TurboRepo 패키지 의존성
+
+```json
+// packages/utils/package.json
+{
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*"
+  }
+}
+```
+
+#### 1. [@repo/typescript-config](/packages/typescript-config/README.md)
+
+타입스크립트 설정 파일을 사용하기 위한 패키지입니다.  <br/>
+공용으로 정의된 설정을 extends(확장) 하여 사용하고 있습니다:
+
+```json
+// packages/utils/tsconfig.json
+{
+  "extends": "@repo/typescript-config/base.json",
+}
+```
+
+#### 2. [apps/blog](/apps/blog/README.md), [apps/portfolio](/apps/portfolio/README.md)
+
+직접적으로 의존하고 있진 않지만, 각 애플리케이션에서 `@repo/utils` 패키지에서 내보낸 모듈을 사용하고 있습니다:
+
+```json
+// packages/utils/package.json
+{
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "import": "./index.ts",
+      "default": "./index.ts"
+    }
+  },
+}
+
+```
+
+기본적으로 `index.ts` 파일을 내보냅니다.
+애플리케이션에서 아래와 같이 사용할 수 있습니다:
+
+```tsx
+import { cn } from "@repo/utils";
+```

--- a/packages/vitest-config/README.md
+++ b/packages/vitest-config/README.md
@@ -1,0 +1,168 @@
+# @repo/vitest-config
+
+테스트 환경을 공용으로 정의하기 위한 패키지입니다. <br/>
+
+
+### 패키지 구조
+
+```filetree
+packages/vitest-config/
+├── configs/
+│   ├── base-config.ts
+│   ├── ui-config.ts
+│   └── ...
+├── scripts/
+├── package.json
+└── ...
+```
+
+<br/>
+
+### 프로젝트 실행 방법
+
+#### 1. 빌드
+
+```bash
+turbo build --filter=@repo/vitest-config
+```
+
+
+### 2. 커버리지 JSON 파일 수집
+
+각 패키지의 coverage 파일을 `vitest-config/raw` 폴더에 수집합니다.
+
+```bash
+turbo collect-json-reports
+```
+
+### 3. 커버리지 JSON 파일 병합
+수집된 개별 커버리지 파일을 `vitest-config/merged` 폴더에 하나로 병합합니다.
+
+```bash
+turbo merge-json-reports
+```
+
+### 4. 커버리지 리포트 생성
+
+병합된 커버리지 파일을 기반으로 커버리지 리포트를 생성합니다.
+
+```bash
+turbo report
+```
+
+### 5. 커버리지 리포트 확인
+
+```bash
+turbo view-report
+```
+
+
+<br/>
+
+### 1. configs/base-config.ts
+
+기본 테스트 환경을 정의하는 파일입니다.
+
+```tsx
+import { defineConfig } from "vitest/config";
+
+export const baseConfig = defineConfig({
+  test: {
+    coverage: {
+      provider: "istanbul",
+      enabled: true,
+    },
+  },
+});
+```
+
+- `provider: "istanbul"`: 코드 커버리지 측정에 Istanbul을 사용합니다.
+- `enabled: true`: 코드 커버리지 측정을 활성화합니다.
+
+
+<br/>
+
+### 2. configs/ui-config.ts
+
+UI 테스트 환경을 정의하는 파일입니다.
+
+```tsx
+import react from "@vitejs/plugin-react";
+import { defineProject, mergeConfig } from "vitest/config";
+import { baseConfig } from "./base-config.js";
+
+export const uiConfig = mergeConfig(
+  baseConfig,
+  defineProject({
+    plugins: [react()],
+
+    test: {
+      environment: "jsdom",
+      pool: "threads",
+      globals: true,
+    },
+  }),
+);
+```
+
+- `react()`: React 컴포넌트를 테스트할 수 있도록 JSX 변환과 Hot Module Replacement를 제공합니다.
+- `environment: "jsdom"`: 브라우저 환경을 시뮬레이션하는 jsdom을 사용합니다. DOM API와 브라우저 globals를 제공합니다.
+- `pool: "threads"`: 테스트를 별도 워커 스레드에서 병렬로 실행합니다.
+- `globals: true`: describe, it, test, expect 등의 전역 함수를 자동으로 가져옵니다.
+
+
+<br/>
+
+
+### TurboRepo 패키지 의존성
+
+
+```json
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+  }
+```
+
+#### 1. [@repo/typescript-config](/packages/typescript-config/README.md)
+
+타입스크립트 설정 파일을 사용하기 위한 패키지입니다.  <br/>
+공용으로 정의된 설정을 extends(확장) 하여 사용하고 있습니다:
+
+```json
+// packages/vitest-config/tsconfig.json
+{
+  "extends": "@repo/typescript-config/base.json",
+}
+```
+
+
+#### 2. [apps/blog](/apps/blog/README.md), [apps/portfolio](/apps/portfolio/README.md)
+
+
+직접적으로 의존하고 있진 않지만, 각 애플리케이션에서 `@repo/vitest-config` 패키지에서 내보낸 모듈을 사용하고 있습니다:
+
+```json
+"exports": {
+  "./base": "./dist/configs/base-config.js",
+  "./ui": "./dist/configs/ui-config.js"
+},
+```
+
+base와 ui config 모듈을 내보냅니다.
+애플리케이션에선 아래와 같이 사용할 수 있습니다:
+
+```ts
+import { resolve } from "node:path";
+import { uiConfig } from "@repo/vitest-config/ui";
+import { mergeConfig } from "vitest/config";
+
+export default mergeConfig(uiConfig, {
+  resolve: {
+    ...
+  },
+
+  test: {
+    ...
+  },
+});
+```

--- a/packages/vitest-config/turbo.json
+++ b/packages/vitest-config/turbo.json
@@ -14,7 +14,7 @@
     },
     "report": {
       "dependsOn": ["merge-json-reports"],
-      "inputs": ["coverage/merge"],
+      "inputs": ["coverage/merged/**"],
       "outputs": ["coverage/report/**"]
     },
     "view-report": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       '@vercel/og':
         specifier: ^0.6.5
         version: 0.6.5
@@ -106,9 +109,6 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
-      '@repo/utils':
-        specifier: workspace:*
-        version: link:../../packages/utils
       '@repo/vitest-config':
         specifier: workspace:*
         version: link:../../packages/vitest-config
@@ -121,13 +121,13 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
-      '@repo/utils':
-        specifier: workspace:*
-        version: link:../../packages/utils
       '@repo/vitest-config':
         specifier: workspace:*
         version: link:../../packages/vitest-config

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,7 @@
       "cache": false,
       "persistent": true
     },
+    "test:coverage": {},
     "transit": {
       "dependsOn": ["^transit"]
     },


### PR DESCRIPTION

### 작업 설명

프로젝트 문서화를 위해 README.md를 작성하였습니다.

### 개발 변경사항

- 프로젝트 명칭을 OnlyOn -> Only On으로 통일
- 각 애플리케이션, 라이브러리 README.md 문서화
- @repo/utils 의존성을 dependencies로 명시함
- coverage view-report 시 최신 내용으로 반영되지 않고 있어 테스트 실행 시 생성되는 신규 커버리지 파일을 바라볼 수 있도록 개선함

### 테스트 방법

1. turbo 태스크가 기존대로 잘 동작하는지 확인
2. 각 REAMDE.md 문서 내용이 올바른지, 링크가 올바르게 연결되어있는지 확인

### 스크린샷

#### After

<img width="666" height="825" alt="스크린샷 2025-07-20 오후 6 30 50" src="https://github.com/user-attachments/assets/f4e57d46-7e9c-420a-b383-97706e4447da" />


### 레퍼런스

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**문서화**
  * 메인, 블로그, 포트폴리오, utils, typescript-config, ui, vitest-config 패키지의 README를 한글로 대폭 확장 및 신규 작성하여 프로젝트 개요, 사용법, 패키지 구조, 환경 변수, 배포, 테스트, 의존성 등 상세 안내 추가
  * 블로그와 포트폴리오 앱의 README에 개발, 빌드, 테스트, 배포, 디렉터리 구조, 예제 코드, TurboRepo 사용법 등 구체적 설명 포함

**새 기능**
  * 블로그 및 포트폴리오 앱에 환경 변수 예시 파일(.env.example) 추가
  * 루트 turbo.json에 test:coverage 태스크 추가
  * vitest-config 패키지에 테스트 환경 구성 및 공유 설정 도입

**버그 수정**
  * 블로그 및 포트폴리오 앱의 .gitignore에서 .env* → .env로 변경하여 환경 파일 관리 개선
  * vitest-config의 turbo.json에서 report 태스크 입력 경로 수정

**스타일**
  * UI 헤더 컴포넌트의 메인 링크 텍스트를 "OnlyOn."에서 "Only On."으로 변경

**리팩터**
  * 블로그 및 포트폴리오 앱에서 @repo/utils 의존성을 devDependencies에서 dependencies로 이동
  * 포트폴리오 tsconfig.json에서 불필요한 경로 매핑 제거
  * vitest-config의 커버리지 수집 스크립트 개선 및 로깅 강화

**테스트**
  * ImageZoom 컴포넌트 테스트에서 불필요한 디버깅 코드 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->